### PR TITLE
feat(message): implement ed25519 payload signing and signature verifi…

### DIFF
--- a/src/message/errors.rs
+++ b/src/message/errors.rs
@@ -1,0 +1,8 @@
+#[derive(thiserror::Error, Debug)]
+pub enum SignError {
+    #[error("Invalid Ed25519 signature")]
+    InvalidSignature,
+
+    #[error("Malformed public key: {0}")]
+    MalformedPublicKey(String),
+}

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -1,1 +1,3 @@
+pub mod errors;
+pub mod signing;
 pub mod types;

--- a/src/message/signing.rs
+++ b/src/message/signing.rs
@@ -1,0 +1,36 @@
+use crate::message::errors::SignError;
+use crate::message::types::TransactionEnvelope;
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use sha2::{Digest, Sha256};
+
+fn generate_payload_hash(envelope: &TransactionEnvelope) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(&envelope.origin_pubkey);
+    hasher.update(envelope.timestamp.to_be_bytes());
+    hasher.update(envelope.tx_xdr.as_bytes());
+    hasher.finalize().into()
+}
+
+pub fn sign_envelope(
+    keypair: &SigningKey,
+    envelope: &mut TransactionEnvelope,
+) -> Result<(), SignError> {
+    let hash = generate_payload_hash(envelope);
+    let signature = keypair.sign(&hash);
+    envelope.signature = signature.to_bytes();
+    Ok(())
+}
+
+pub fn verify_signature(envelope: &TransactionEnvelope) -> Result<bool, SignError> {
+    let verifying_key = VerifyingKey::from_bytes(&envelope.origin_pubkey)
+        .map_err(|e| SignError::MalformedPublicKey(e.to_string()))?;
+
+    let hash = generate_payload_hash(envelope);
+
+    let signature = Signature::from_bytes(&envelope.signature);
+
+    match verifying_key.verify(&hash, &signature) {
+        Ok(_) => Ok(true),
+        Err(_) => Err(SignError::InvalidSignature),
+    }
+}

--- a/tests/message_test.rs
+++ b/tests/message_test.rs
@@ -1,0 +1,102 @@
+use ed25519_dalek::SigningKey;
+use rand::rngs::OsRng;
+use stellarconduit_core::message::{
+    signing::{sign_envelope, verify_signature},
+    types::TransactionEnvelope,
+};
+
+fn make_test_envelope(keypair: &SigningKey, tx_xdr: &str) -> TransactionEnvelope {
+    TransactionEnvelope {
+        message_id: [0u8; 32],
+        origin_pubkey: keypair.verifying_key().to_bytes(),
+        tx_xdr: tx_xdr.to_string(),
+        ttl_hops: 10,
+        timestamp: 1672531200,
+        signature: [0u8; 64],
+    }
+}
+
+#[test]
+fn test_sign_and_verify_success() {
+    let mut csprng = OsRng;
+    let keypair = SigningKey::generate(&mut csprng);
+    let mut envelope = make_test_envelope(&keypair, "AAAAAQAAAAAAAAAA");
+
+    sign_envelope(&keypair, &mut envelope).expect("signing should succeed");
+    let result = verify_signature(&envelope).expect("verification should succeed");
+    assert!(result, "signature should be valid");
+}
+
+#[test]
+fn test_verify_tampered_tx_xdr() {
+    let mut csprng = OsRng;
+    let keypair = SigningKey::generate(&mut csprng);
+    let mut envelope = make_test_envelope(&keypair, "AAAAAQAAAAAAAAAA");
+
+    sign_envelope(&keypair, &mut envelope).expect("signing should succeed");
+
+    // Tamper with the payload after signing
+    envelope.tx_xdr = "TAMPERED_PAYLOAD_XDR".to_string();
+
+    let result = verify_signature(&envelope);
+    assert!(
+        result.is_err(),
+        "verification should fail due to tampered tx_xdr"
+    );
+}
+
+#[test]
+fn test_verify_tampered_timestamp() {
+    let mut csprng = OsRng;
+    let keypair = SigningKey::generate(&mut csprng);
+    let mut envelope = make_test_envelope(&keypair, "AAAAAQAAAAAAAAAA");
+
+    sign_envelope(&keypair, &mut envelope).expect("signing should succeed");
+
+    // Tamper with the timestamp after signing
+    envelope.timestamp += 1;
+
+    let result = verify_signature(&envelope);
+    assert!(
+        result.is_err(),
+        "verification should fail due to tampered timestamp"
+    );
+}
+
+#[test]
+fn test_verify_wrong_key() {
+    let mut csprng = OsRng;
+    let keypair_a = SigningKey::generate(&mut csprng);
+    let keypair_b = SigningKey::generate(&mut csprng);
+
+    let mut envelope = make_test_envelope(&keypair_a, "AAAAAQAAAAAAAAAA");
+    // Sign with key A but put key B's pubkey as origin
+    sign_envelope(&keypair_a, &mut envelope).expect("signing should succeed");
+    // Swap the pubkey to a different one
+    envelope.origin_pubkey = keypair_b.verifying_key().to_bytes();
+
+    let result = verify_signature(&envelope);
+    assert!(
+        result.is_err(),
+        "verification should fail when origin_pubkey doesn't match signing key"
+    );
+}
+
+#[test]
+fn test_verify_invalid_signature() {
+    let mut csprng = OsRng;
+    let keypair = SigningKey::generate(&mut csprng);
+    let mut envelope = make_test_envelope(&keypair, "AAAAAQAAAAAAAAAA");
+
+    sign_envelope(&keypair, &mut envelope).expect("signing should succeed");
+
+    // Corrupt the signature bytes
+    envelope.signature[0] ^= 0xFF;
+    envelope.signature[1] ^= 0xFF;
+
+    let result = verify_signature(&envelope);
+    assert!(
+        result.is_err(),
+        "verification should fail with corrupted signature bytes"
+    );
+}


### PR DESCRIPTION
…cation


# Implement Ed25519 payload signing and signature verification

Closes #2

## Implementation Details

- Defined `SignError` in `src/message/errors.rs` using `thiserror`.
- Implemented `sign_envelope(keypair, envelope)` in `src/message/signing.rs`, which generates a deterministic SHA-256 hash of the envelope's `origin_pubkey`, `timestamp`, and `tx_xdr` and populates the `signature` field.
- Implemented `verify_signature(envelope)` which reconstructs the same hash and validates the signature using the `origin_pubkey` field as the verifying key.
- Exposed both modules from `src/message/mod.rs`.
- Added full test coverage in `tests/message_test.rs`:
  - `test_sign_and_verify_success` — valid signature verifies successfully
  - `test_verify_tampered_tx_xdr` — tampered XDR rejected
  - `test_verify_tampered_timestamp` — tampered timestamp rejected
  - `test_verify_wrong_key` — mismatched origin key rejected
  - `test_verify_invalid_signature` — corrupted signature bytes rejected
- All 8 tests pass (`cargo test -p stellarconduit-core`).
