### PR TITLE
feat(peer): implement peer data structures and reputation scoring

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod message;
+pub mod peer;
 
 pub fn add(left: u64, right: u64) -> u64 {
     left + right

--- a/src/peer/identity.rs
+++ b/src/peer/identity.rs
@@ -1,0 +1,33 @@
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use std::fmt;
+
+#[derive(Clone, Debug)]
+pub struct PeerIdentity {
+    /// Ed25519 public key bytes
+    pub pubkey: [u8; 32],
+    /// Hex-encoded string representation for logging
+    pub display_id: String,
+}
+
+impl PeerIdentity {
+    pub fn new(pubkey: [u8; 32]) -> Self {
+        let display_id = pubkey.iter().map(|b| format!("{:02x}", b)).collect();
+        Self { pubkey, display_id }
+    }
+
+    /// Verify an Ed25519 signature over `message` using this peer's public key.
+    /// Returns `false` on bad key or failed verification.
+    pub fn verify_signature(&self, message: &[u8], signature: &[u8; 64]) -> bool {
+        let Ok(verifying_key) = VerifyingKey::from_bytes(&self.pubkey) else {
+            return false;
+        };
+        let sig = Signature::from_bytes(signature);
+        verifying_key.verify(message, &sig).is_ok()
+    }
+}
+
+impl fmt::Display for PeerIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", &self.display_id[..16])
+    }
+}

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -1,0 +1,3 @@
+pub mod identity;
+pub mod peer;
+pub mod reputation;

--- a/src/peer/peer.rs
+++ b/src/peer/peer.rs
@@ -1,0 +1,30 @@
+use crate::peer::identity::PeerIdentity;
+
+pub struct Peer {
+    pub identity: PeerIdentity,
+    /// Reputation score: 0–100. Drops to 0 triggers a ban.
+    pub reputation: u32,
+    pub is_banned: bool,
+    /// Unix timestamp of the last observed activity from this peer
+    pub last_seen_unix_sec: u64,
+    /// Bitmask: 0x01 = BLE, 0x02 = WiFi-Direct
+    pub supported_transports: u8,
+    pub is_relay_node: bool,
+    pub bytes_sent: u64,
+    pub bytes_received: u64,
+}
+
+impl Peer {
+    pub fn new(pubkey: [u8; 32]) -> Self {
+        Self {
+            identity: PeerIdentity::new(pubkey),
+            reputation: 100,
+            is_banned: false,
+            last_seen_unix_sec: 0,
+            supported_transports: 0,
+            is_relay_node: false,
+            bytes_sent: 0,
+            bytes_received: 0,
+        }
+    }
+}

--- a/src/peer/reputation.rs
+++ b/src/peer/reputation.rs
@@ -1,0 +1,44 @@
+use crate::peer::peer::Peer;
+
+pub enum PenaltyReason {
+    InvalidSignature,
+    DuplicateMessageFlood,
+    ConnectionDropped,
+}
+
+pub enum RewardReason {
+    SuccessfullyRoutedTx,
+    ValidNewGossipEnvelope,
+}
+
+impl PenaltyReason {
+    fn points(&self) -> u32 {
+        match self {
+            PenaltyReason::InvalidSignature => 20,
+            PenaltyReason::DuplicateMessageFlood => 10,
+            PenaltyReason::ConnectionDropped => 2,
+        }
+    }
+}
+
+impl RewardReason {
+    fn points(&self) -> u32 {
+        match self {
+            RewardReason::SuccessfullyRoutedTx => 5,
+            RewardReason::ValidNewGossipEnvelope => 2,
+        }
+    }
+}
+
+pub fn apply_penalty(peer: &mut Peer, reason: PenaltyReason) {
+    let penalty = reason.points();
+    peer.reputation = peer.reputation.saturating_sub(penalty);
+    if peer.reputation == 0 {
+        peer.is_banned = true;
+    }
+}
+
+pub fn apply_reward(peer: &mut Peer, reason: RewardReason) {
+    let reward = reason.points();
+    peer.reputation = (peer.reputation + reward).min(100);
+}

--- a/tests/peer_test.rs
+++ b/tests/peer_test.rs
@@ -1,0 +1,148 @@
+use ed25519_dalek::SigningKey;
+use rand::rngs::OsRng;
+use stellarconduit_core::peer::{
+    identity::PeerIdentity,
+    peer::Peer,
+    reputation::{apply_penalty, apply_reward, PenaltyReason, RewardReason},
+};
+
+// ──── PeerIdentity tests ────────────────────────────────────────────────────
+
+#[test]
+fn test_peer_identity_display_id_is_hex() {
+    let pubkey = [0xABu8; 32];
+    let identity = PeerIdentity::new(pubkey);
+    assert_eq!(
+        identity.display_id.len(),
+        64,
+        "hex string should be 64 chars"
+    );
+    assert!(
+        identity.display_id.chars().all(|c| c.is_ascii_hexdigit()),
+        "display_id should be valid hex"
+    );
+}
+
+#[test]
+fn test_peer_identity_verify_valid_signature() {
+    let mut csprng = OsRng;
+    let signing_key = SigningKey::generate(&mut csprng);
+    let pubkey = signing_key.verifying_key().to_bytes();
+    let identity = PeerIdentity::new(pubkey);
+
+    use ed25519_dalek::Signer;
+    let message = b"test payload";
+    let signature = signing_key.sign(message).to_bytes();
+
+    assert!(identity.verify_signature(message, &signature));
+}
+
+#[test]
+fn test_peer_identity_reject_bad_signature() {
+    let mut csprng = OsRng;
+    let signing_key = SigningKey::generate(&mut csprng);
+    let pubkey = signing_key.verifying_key().to_bytes();
+    let identity = PeerIdentity::new(pubkey);
+
+    // Corrupted signature
+    let bad_signature = [0u8; 64];
+    assert!(!identity.verify_signature(b"test payload", &bad_signature));
+}
+
+// ──── Peer tests ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_peer_initial_state() {
+    let peer = Peer::new([1u8; 32]);
+    assert_eq!(peer.reputation, 100);
+    assert!(!peer.is_banned);
+    assert_eq!(peer.bytes_sent, 0);
+    assert_eq!(peer.bytes_received, 0);
+    assert_eq!(peer.supported_transports, 0);
+    assert!(!peer.is_relay_node);
+}
+
+#[test]
+fn test_peer_transport_bitmask() {
+    let mut peer = Peer::new([1u8; 32]);
+    peer.supported_transports |= 0x01; // BLE
+    peer.supported_transports |= 0x02; // WiFi-Direct
+    assert_eq!(peer.supported_transports & 0x01, 0x01, "BLE should be set");
+    assert_eq!(
+        peer.supported_transports & 0x02,
+        0x02,
+        "WiFi-Direct should be set"
+    );
+}
+
+// ──── Reputation tests ───────────────────────────────────────────────────────
+
+#[test]
+fn test_penalty_invalid_signature() {
+    let mut peer = Peer::new([2u8; 32]);
+    apply_penalty(&mut peer, PenaltyReason::InvalidSignature); // -20
+    assert_eq!(peer.reputation, 80);
+    assert!(!peer.is_banned);
+}
+
+#[test]
+fn test_penalty_duplicate_message_flood() {
+    let mut peer = Peer::new([2u8; 32]);
+    apply_penalty(&mut peer, PenaltyReason::DuplicateMessageFlood); // -10
+    assert_eq!(peer.reputation, 90);
+}
+
+#[test]
+fn test_penalty_connection_dropped() {
+    let mut peer = Peer::new([2u8; 32]);
+    apply_penalty(&mut peer, PenaltyReason::ConnectionDropped); // -2
+    assert_eq!(peer.reputation, 98);
+}
+
+#[test]
+fn test_penalty_triggers_ban_at_zero() {
+    let mut peer = Peer::new([3u8; 32]);
+    // Drive reputation to 0 with InvalidSignature (-20 each)
+    for _ in 0..5 {
+        apply_penalty(&mut peer, PenaltyReason::InvalidSignature);
+    }
+    assert_eq!(peer.reputation, 0);
+    assert!(
+        peer.is_banned,
+        "peer should be banned when reputation hits 0"
+    );
+}
+
+#[test]
+fn test_penalty_saturates_at_zero() {
+    let mut peer = Peer::new([4u8; 32]);
+    for _ in 0..20 {
+        apply_penalty(&mut peer, PenaltyReason::InvalidSignature);
+    }
+    assert_eq!(peer.reputation, 0, "reputation should not underflow");
+}
+
+#[test]
+fn test_reward_successfully_routed_tx() {
+    let mut peer = Peer::new([5u8; 32]);
+    apply_penalty(&mut peer, PenaltyReason::InvalidSignature); // reputation = 80
+    apply_reward(&mut peer, RewardReason::SuccessfullyRoutedTx); // +5 → 85
+    assert_eq!(peer.reputation, 85);
+}
+
+#[test]
+fn test_reward_valid_gossip_envelope() {
+    let mut peer = Peer::new([5u8; 32]);
+    apply_penalty(&mut peer, PenaltyReason::DuplicateMessageFlood); // reputation = 90
+    apply_reward(&mut peer, RewardReason::ValidNewGossipEnvelope); // +2 → 92
+    assert_eq!(peer.reputation, 92);
+}
+
+#[test]
+fn test_reward_caps_at_100() {
+    let mut peer = Peer::new([6u8; 32]);
+    // Already at 100, reward should not overflow
+    apply_reward(&mut peer, RewardReason::SuccessfullyRoutedTx);
+    apply_reward(&mut peer, RewardReason::ValidNewGossipEnvelope);
+    assert_eq!(peer.reputation, 100, "reputation should not exceed 100");
+}


### PR DESCRIPTION
# Implement Peer Identity data models and reputation scoring

Closes #3

## Implementation Details

- **`src/peer/identity.rs`** — `PeerIdentity` struct with `new(pubkey)` that stores the 32-byte key and generates a hex `display_id`, plus `verify_signature(message, sig)` using `ed25519-dalek`.
- **`src/peer/peer.rs`** — `Peer` struct tracking identity, reputation (starts at 100), ban status, transport bitmask (0x01=BLE, 0x02=WiFi-Direct), relay flag, and byte counters.
- **`src/peer/reputation.rs`** — `PenaltyReason` and `RewardReason` enums; `apply_penalty()` uses saturating subtraction and sets `is_banned = true` when reputation bottoms at 0; `apply_reward()` caps at 100.
- All modules exposed via `src/peer/mod.rs` and `src/lib.rs`.
- **`tests/peer_test.rs`** — 13 tests covering identity verification, transport bitmask, initial peer state, all penalty variants (with ban trigger and underflow guard), and all reward variants (including 100-cap).
- All 21 tests pass (`cargo test -p stellarconduit-core`).
