### PR TITLE
feat(discovery): implement peer list management and ttl expiry

### DIFF
--- a/src/discovery/events.rs
+++ b/src/discovery/events.rs
@@ -1,0 +1,10 @@
+use crate::peer::identity::PeerIdentity;
+
+pub enum DiscoveryEvent {
+    /// A new peer was seen for the first time
+    PeerDiscovered(PeerIdentity),
+    /// A known peer sent a fresh beacon; includes current signal strength (RSSI)
+    PeerUpdated(PeerIdentity, u8),
+    /// A peer has exceeded the expiry window and is considered offline
+    PeerLost(PeerIdentity),
+}

--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -1,0 +1,2 @@
+pub mod events;
+pub mod peer_list;

--- a/src/discovery/peer_list.rs
+++ b/src/discovery/peer_list.rs
@@ -1,0 +1,116 @@
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::discovery::events::DiscoveryEvent;
+use crate::peer::peer::Peer;
+
+pub struct PeerList {
+    /// Maps public key to the Peer struct
+    peers: HashMap<[u8; 32], Peer>,
+    /// How many seconds before a peer is considered offline
+    expiry_seconds: u64,
+}
+
+fn now_unix_sec() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+impl PeerList {
+    pub fn new(expiry_seconds: u64) -> Self {
+        Self {
+            peers: HashMap::new(),
+            expiry_seconds,
+        }
+    }
+
+    /// Insert a new peer or update the last-seen timestamp for an existing one.
+    /// Returns `PeerDiscovered` for first contact, `PeerUpdated` for subsequent contacts.
+    pub fn insert_or_update(
+        &mut self,
+        pubkey: [u8; 32],
+        signal_strength: u8,
+    ) -> Option<DiscoveryEvent> {
+        let now = now_unix_sec();
+
+        if let Some(peer) = self.peers.get_mut(&pubkey) {
+            peer.last_seen_unix_sec = now;
+            Some(DiscoveryEvent::PeerUpdated(
+                peer.identity.clone(),
+                signal_strength,
+            ))
+        } else {
+            let mut peer = Peer::new(pubkey);
+            peer.last_seen_unix_sec = now;
+            let identity = peer.identity.clone();
+            self.peers.insert(pubkey, peer);
+            Some(DiscoveryEvent::PeerDiscovered(identity))
+        }
+    }
+
+    /// Returns only peers whose last-seen timestamp is within the expiry window.
+    pub fn get_active_peers(&self) -> Vec<&Peer> {
+        let now = now_unix_sec();
+        self.peers
+            .values()
+            .filter(|p| now.saturating_sub(p.last_seen_unix_sec) <= self.expiry_seconds)
+            .collect()
+    }
+
+    /// Removes stale peers (beyond expiry window) and returns a `PeerLost` event for each.
+    pub fn prune_stale_peers(&mut self) -> Vec<DiscoveryEvent> {
+        let now = now_unix_sec();
+        let expiry = self.expiry_seconds;
+
+        let stale_keys: Vec<[u8; 32]> = self
+            .peers
+            .iter()
+            .filter(|(_, p)| now.saturating_sub(p.last_seen_unix_sec) > expiry)
+            .map(|(k, _)| *k)
+            .collect();
+
+        stale_keys
+            .into_iter()
+            .filter_map(|key| {
+                self.peers
+                    .remove(&key)
+                    .map(|p| DiscoveryEvent::PeerLost(p.identity))
+            })
+            .collect()
+    }
+
+    /// Returns total number of tracked peers (including stale ones not yet pruned).
+    pub fn len(&self) -> usize {
+        self.peers.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.peers.is_empty()
+    }
+
+    /// Test helper: directly set last_seen_unix_sec for a peer by pubkey.
+    pub fn set_last_seen(&mut self, pubkey: &[u8; 32], ts: u64) {
+        if let Some(p) = self.peers.get_mut(pubkey) {
+            p.last_seen_unix_sec = ts;
+        }
+    }
+}
+
+/// Background pruning stub — call this on a Tokio task to auto-prune every `interval_secs`.
+/// The caller is responsible for wrapping `peer_list` in an `Arc<tokio::sync::Mutex<PeerList>>`.
+pub async fn background_pruning_loop(
+    peer_list: std::sync::Arc<tokio::sync::Mutex<PeerList>>,
+    interval_secs: u64,
+) {
+    let interval = std::time::Duration::from_secs(interval_secs);
+    loop {
+        tokio::time::sleep(interval).await;
+        let mut list = peer_list.lock().await;
+        let lost = list.prune_stale_peers();
+        if !lost.is_empty() {
+            log::debug!("Pruned {} stale peer(s) from PeerList", lost.len());
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod discovery;
 pub mod message;
 pub mod peer;
 

--- a/tests/discovery_test.rs
+++ b/tests/discovery_test.rs
@@ -1,0 +1,133 @@
+use stellarconduit_core::discovery::{events::DiscoveryEvent, peer_list::PeerList};
+
+// ──── insert_or_update ───────────────────────────────────────────────────────
+
+#[test]
+fn test_new_peer_returns_peer_discovered() {
+    let mut list = PeerList::new(60);
+    let pubkey = [1u8; 32];
+    let event = list.insert_or_update(pubkey, 80).unwrap();
+    assert!(matches!(event, DiscoveryEvent::PeerDiscovered(_)));
+}
+
+#[test]
+fn test_known_peer_returns_peer_updated() {
+    let mut list = PeerList::new(60);
+    let pubkey = [2u8; 32];
+    list.insert_or_update(pubkey, 70); // first insert
+    let event = list.insert_or_update(pubkey, 75).unwrap(); // second = update
+    assert!(matches!(event, DiscoveryEvent::PeerUpdated(_, 75)));
+}
+
+#[test]
+fn test_signal_strength_passed_through_in_update() {
+    let mut list = PeerList::new(60);
+    let pubkey = [3u8; 32];
+    list.insert_or_update(pubkey, 50);
+    if let Some(DiscoveryEvent::PeerUpdated(_, rssi)) = list.insert_or_update(pubkey, 99) {
+        assert_eq!(rssi, 99);
+    } else {
+        panic!("Expected PeerUpdated");
+    }
+}
+
+// ──── get_active_peers ───────────────────────────────────────────────────────
+
+#[test]
+fn test_active_peers_returns_fresh_peers() {
+    let mut list = PeerList::new(60);
+    list.insert_or_update([10u8; 32], 80);
+    list.insert_or_update([11u8; 32], 60);
+    assert_eq!(list.get_active_peers().len(), 2);
+}
+
+#[test]
+fn test_stale_peers_not_returned_by_get_active_peers() {
+    let mut list = PeerList::new(30);
+    let pubkey = [20u8; 32];
+    list.insert_or_update(pubkey, 80);
+
+    // Manually backdate last_seen to simulate expiry
+    let old_ts = 0u64; // very old timestamp
+    list.set_last_seen(&pubkey, old_ts);
+
+    assert_eq!(
+        list.get_active_peers().len(),
+        0,
+        "stale peer should not appear in active list"
+    );
+}
+
+// ──── prune_stale_peers ──────────────────────────────────────────────────────
+
+#[test]
+fn test_prune_removes_stale_peers() {
+    let mut list = PeerList::new(30);
+    let pubkey = [30u8; 32];
+    list.insert_or_update(pubkey, 80);
+    list.set_last_seen(&pubkey, 0); // force stale
+
+    let events = list.prune_stale_peers();
+    assert_eq!(events.len(), 1, "should have one PeerLost event");
+    assert!(matches!(events[0], DiscoveryEvent::PeerLost(_)));
+    assert_eq!(list.len(), 0, "stale peer should be removed");
+}
+
+#[test]
+fn test_prune_keeps_fresh_peers() {
+    let mut list = PeerList::new(60);
+    list.insert_or_update([40u8; 32], 80); // fresh
+    let stale = [41u8; 32];
+    list.insert_or_update(stale, 80);
+    list.set_last_seen(&stale, 0); // force stale
+
+    let events = list.prune_stale_peers();
+    assert_eq!(events.len(), 1, "only one peer should be pruned");
+    assert_eq!(list.len(), 1, "fresh peer should remain");
+}
+
+#[test]
+fn test_prune_returns_empty_when_all_fresh() {
+    let mut list = PeerList::new(60);
+    list.insert_or_update([50u8; 32], 80);
+    list.insert_or_update([51u8; 32], 60);
+
+    let events = list.prune_stale_peers();
+    assert!(events.is_empty(), "no events when no stale peers");
+}
+
+#[test]
+fn test_prune_emits_peer_lost_with_correct_identity() {
+    let mut list = PeerList::new(30);
+    let pubkey = [60u8; 32];
+    list.insert_or_update(pubkey, 80);
+    list.set_last_seen(&pubkey, 0);
+
+    let events = list.prune_stale_peers();
+    if let DiscoveryEvent::PeerLost(identity) = &events[0] {
+        assert_eq!(identity.pubkey, pubkey);
+    } else {
+        panic!("Expected PeerLost event");
+    }
+}
+
+// ──── general ────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_empty_list_is_empty() {
+    let list = PeerList::new(60);
+    assert!(list.is_empty());
+    assert_eq!(list.len(), 0);
+}
+
+#[test]
+fn test_insert_increments_len() {
+    let mut list = PeerList::new(60);
+    list.insert_or_update([70u8; 32], 80);
+    assert_eq!(list.len(), 1);
+    list.insert_or_update([71u8; 32], 80);
+    assert_eq!(list.len(), 2);
+    // Updating existing peer should not increment
+    list.insert_or_update([70u8; 32], 50);
+    assert_eq!(list.len(), 2);
+}


### PR DESCRIPTION
# Implement Peer list management and expiry

Closes #4

## Implementation Details

- **`src/discovery/events.rs`** — `DiscoveryEvent` enum: `PeerDiscovered`, `PeerUpdated(identity, rssi)`, `PeerLost`.
- **`src/discovery/peer_list.rs`** — `PeerList` with:
  - `new(expiry_seconds)` — configurable TTL
  - `insert_or_update(pubkey, signal_strength)` — returns `PeerDiscovered` on first contact, `PeerUpdated` thereafter, and stamps `last_seen_unix_sec`
  - `get_active_peers()` — filters out peers beyond TTL
  - `prune_stale_peers()` — removes expired peers and returns `PeerLost` events for each
  - `background_pruning_loop(Arc<Mutex<PeerList>>, interval)` — async Tokio stub for spawning auto-prune
- All modules exposed via `src/discovery/mod.rs` and `src/lib.rs`.
- **`tests/discovery_test.rs`** — 11 tests covering: `PeerDiscovered`/`PeerUpdated` return values, signal strength pass-through, active peer filtering, stale peer exclusion, pruning with correct identity in `PeerLost`, fresh-peer preservation during pruning, and length invariants.
- All 32 tests pass (`cargo test -p stellarconduit-core`).
