### PR TITLE
feat(transport): introduce connection trait and state machine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ soroban-sdk = "22.0.0"
 
 # Async and networking basics (for WiFi-Direct / Transport abstraction)
 tokio = { version = "1.37", features = ["full"] }
+async-trait = "0.1"
 futures = "0.3"
 
 # Data structures and bloom filters for gossip deduplication

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod discovery;
 pub mod message;
 pub mod peer;
+pub mod transport;
 
 pub fn add(left: u64, right: u64) -> u64 {
     left + right

--- a/src/transport/connection.rs
+++ b/src/transport/connection.rs
@@ -1,0 +1,44 @@
+use async_trait::async_trait;
+
+use crate::message::types::ProtocolMessage;
+use crate::peer::identity::PeerIdentity;
+use crate::transport::errors::TransportError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectionState {
+    Disconnected,
+    Connecting,
+    Connected,
+    Disconnecting,
+    Failed(TransportError),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportType {
+    Ble,
+    WifiDirect,
+}
+
+#[async_trait]
+pub trait Connection: Send + Sync {
+    /// Retrieve the peer on the other side of this connection
+    fn remote_peer(&self) -> PeerIdentity;
+
+    /// Which transport is currently being used
+    fn transport_type(&self) -> TransportType;
+
+    /// Current connection state
+    fn state(&self) -> ConnectionState;
+
+    /// Attempt to establish the physical connection
+    async fn connect(&mut self) -> Result<(), TransportError>;
+
+    /// Send a serialized protocol message. Returns an error if not connected or if IO fails.
+    async fn send(&mut self, msg: ProtocolMessage) -> Result<(), TransportError>;
+
+    /// Block until a message is received from this peer
+    async fn recv(&mut self) -> Result<ProtocolMessage, TransportError>;
+
+    /// Safely close the connection
+    async fn disconnect(&mut self) -> Result<(), TransportError>;
+}

--- a/src/transport/errors.rs
+++ b/src/transport/errors.rs
@@ -1,0 +1,13 @@
+#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportError {
+    #[error("Not connected")]
+    NotConnected,
+    #[error("Connection refused")]
+    ConnectionRefused,
+    #[error("Connection timed out")]
+    Timeout,
+    #[error("Transport disconnected unexpectedly")]
+    BrokenPipe,
+    #[error("Payload too large for transport")]
+    PayloadTooLarge,
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,0 +1,3 @@
+pub mod connection;
+pub mod errors;
+pub mod unified;

--- a/src/transport/unified.rs
+++ b/src/transport/unified.rs
@@ -1,0 +1,6 @@
+/// Re-exports for convenient access to the unified transport abstraction.
+pub use crate::transport::connection::{Connection, ConnectionState, TransportType};
+pub use crate::transport::errors::TransportError;
+
+/// A type-erased, heap-allocated connection handle usable across transports.
+pub type BoxedConnection = Box<dyn Connection>;

--- a/tests/transport_test.rs
+++ b/tests/transport_test.rs
@@ -1,0 +1,182 @@
+use async_trait::async_trait;
+use stellarconduit_core::{
+    message::types::{ProtocolMessage, TransactionEnvelope},
+    peer::identity::PeerIdentity,
+    transport::{
+        connection::{Connection, ConnectionState, TransportType},
+        errors::TransportError,
+    },
+};
+
+// ──── MockConnection ─────────────────────────────────────────────────────────
+// A minimal in-memory implementation of Connection for testing the trait bounds.
+
+struct MockConnection {
+    peer: PeerIdentity,
+    state: ConnectionState,
+    /// Messages queued to be returned on recv()
+    inbox: Vec<ProtocolMessage>,
+}
+
+impl MockConnection {
+    fn new(pubkey: [u8; 32]) -> Self {
+        Self {
+            peer: PeerIdentity::new(pubkey),
+            state: ConnectionState::Disconnected,
+            inbox: Vec::new(),
+        }
+    }
+
+    fn enqueue_message(&mut self, msg: ProtocolMessage) {
+        self.inbox.push(msg);
+    }
+}
+
+#[async_trait]
+impl Connection for MockConnection {
+    fn remote_peer(&self) -> PeerIdentity {
+        self.peer.clone()
+    }
+
+    fn transport_type(&self) -> TransportType {
+        TransportType::Ble
+    }
+
+    fn state(&self) -> ConnectionState {
+        self.state
+    }
+
+    async fn connect(&mut self) -> Result<(), TransportError> {
+        self.state = ConnectionState::Connected;
+        Ok(())
+    }
+
+    async fn send(&mut self, _msg: ProtocolMessage) -> Result<(), TransportError> {
+        if self.state != ConnectionState::Connected {
+            return Err(TransportError::NotConnected);
+        }
+        Ok(())
+    }
+
+    async fn recv(&mut self) -> Result<ProtocolMessage, TransportError> {
+        if self.state != ConnectionState::Connected {
+            return Err(TransportError::NotConnected);
+        }
+        self.inbox.pop().ok_or(TransportError::BrokenPipe)
+    }
+
+    async fn disconnect(&mut self) -> Result<(), TransportError> {
+        self.state = ConnectionState::Disconnected;
+        Ok(())
+    }
+}
+
+// Helper to build a minimal TransactionEnvelope for testing
+fn mock_tx_envelope() -> TransactionEnvelope {
+    TransactionEnvelope {
+        message_id: [0u8; 32],
+        origin_pubkey: [1u8; 32],
+        tx_xdr: "AAAA".to_string(),
+        ttl_hops: 5,
+        timestamp: 1_000_000,
+        signature: [0u8; 64],
+    }
+}
+
+// ──── State machine tests ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_initial_state_is_disconnected() {
+    let conn = MockConnection::new([1u8; 32]);
+    assert_eq!(conn.state(), ConnectionState::Disconnected);
+}
+
+#[tokio::test]
+async fn test_connect_transitions_to_connected() {
+    let mut conn = MockConnection::new([1u8; 32]);
+    conn.connect().await.unwrap();
+    assert_eq!(conn.state(), ConnectionState::Connected);
+}
+
+#[tokio::test]
+async fn test_disconnect_transitions_to_disconnected() {
+    let mut conn = MockConnection::new([1u8; 32]);
+    conn.connect().await.unwrap();
+    conn.disconnect().await.unwrap();
+    assert_eq!(conn.state(), ConnectionState::Disconnected);
+}
+
+// ──── Send / Recv tests ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_send_succeeds_when_connected() {
+    let mut conn = MockConnection::new([2u8; 32]);
+    conn.connect().await.unwrap();
+    let msg = ProtocolMessage::Transaction(mock_tx_envelope());
+    assert!(conn.send(msg).await.is_ok());
+}
+
+#[tokio::test]
+async fn test_send_fails_when_disconnected() {
+    let mut conn = MockConnection::new([2u8; 32]);
+    let msg = ProtocolMessage::Transaction(mock_tx_envelope());
+    let err = conn.send(msg).await.unwrap_err();
+    assert_eq!(err, TransportError::NotConnected);
+}
+
+#[tokio::test]
+async fn test_recv_returns_queued_message() {
+    let mut conn = MockConnection::new([3u8; 32]);
+    conn.connect().await.unwrap();
+    let msg = ProtocolMessage::Transaction(mock_tx_envelope());
+    conn.enqueue_message(msg.clone());
+    let received = conn.recv().await.unwrap();
+    assert_eq!(received, msg);
+}
+
+#[tokio::test]
+async fn test_recv_returns_broken_pipe_when_inbox_empty() {
+    let mut conn = MockConnection::new([3u8; 32]);
+    conn.connect().await.unwrap();
+    let err = conn.recv().await.unwrap_err();
+    assert_eq!(err, TransportError::BrokenPipe);
+}
+
+#[tokio::test]
+async fn test_recv_fails_when_disconnected() {
+    let mut conn = MockConnection::new([3u8; 32]);
+    let err = conn.recv().await.unwrap_err();
+    assert_eq!(err, TransportError::NotConnected);
+}
+
+// ──── Metadata tests ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_remote_peer_identity_matches_pubkey() {
+    let pubkey = [42u8; 32];
+    let conn = MockConnection::new(pubkey);
+    assert_eq!(conn.remote_peer().pubkey, pubkey);
+}
+
+#[tokio::test]
+async fn test_transport_type_is_ble() {
+    let conn = MockConnection::new([1u8; 32]);
+    assert_eq!(conn.transport_type(), TransportType::Ble);
+}
+
+// ──── Send + Sync bound test ─────────────────────────────────────────────────
+
+#[test]
+fn test_connection_is_send_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<MockConnection>();
+}
+
+// ──── ConnectionState equality and Failed variant ────────────────────────────
+
+#[test]
+fn test_connection_state_failed_variant() {
+    let s = ConnectionState::Failed(TransportError::Timeout);
+    assert_eq!(s, ConnectionState::Failed(TransportError::Timeout));
+    assert_ne!(s, ConnectionState::Failed(TransportError::BrokenPipe));
+}


### PR DESCRIPTION
# Define unified Connection abstraction and state machine

Closes #5

## Implementation Details

- **`src/transport/errors.rs`** — `TransportError` enum: `NotConnected`, `ConnectionRefused`, `Timeout`, `BrokenPipe`, `PayloadTooLarge` with `thiserror` derives.
- **`src/transport/connection.rs`** — `ConnectionState` enum (including `Failed(TransportError)`), `TransportType` enum (`Ble`, `WifiDirect`), and the `Connection` async trait using `async-trait`, requiring `Send + Sync`.
- **`src/transport/unified.rs`** — Re-exports of `Connection`, `ConnectionState`, `TransportType`, `TransportError`, and a `BoxedConnection = Box<dyn Connection>` type alias for use by upper layers.
- Added `async-trait = "0.1"` to `Cargo.toml`.
- All modules exposed via `src/transport/mod.rs` and `src/lib.rs`.
- **`tests/transport_test.rs`** — In-memory `MockConnection` implementing the full trait, with 12 tests: initial state, connect/disconnect transitions, send/recv success and error paths, `Send + Sync` bound verification, and `ConnectionState::Failed` variant equality.
- All 45 tests pass (`cargo test -p stellarconduit-core`).
