### PR TITLE
feat(cli): implement stellarconduit daemon interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,16 +31,21 @@ lru = "0.12.3"
 log = "0.4"
 thiserror = "1.0"
 chrono = "0.4"
+clap = { version = "4.5", features = ["derive"] }
+env_logger = "0.11"
 
 # BLE transport
 btleplug = "0.11"
 uuid = { version = "1.8", features = ["v4"] }
 
 [dev-dependencies]
-env_logger = "0.11"
 tokio-test = "0.4"
 mockall = "0.12"
 criterion = "0.5" # For benchmarking
+
+[[bin]]
+name = "stellarconduitd"
+path = "src/bin/stellarconduitd.rs"
 
 [[bench]]
 name = "gossip_bench"

--- a/src/bin/stellarconduitd.rs
+++ b/src/bin/stellarconduitd.rs
@@ -1,0 +1,55 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(version, about = "StellarConduit Core Daemon - Run a local mesh node", long_about = None)]
+struct Args {
+    /// Port to listen on for Virtual WiFi-Direct (TCP) connections
+    #[arg(short, long, default_value_t = 8080)]
+    port: u16,
+
+    /// Is this node a gateway to the internet?
+    #[arg(short, long, default_value_t = false)]
+    is_relay: bool,
+
+    /// Path to the SQLite database
+    #[arg(short, long, default_value = "./stellarconduit.db")]
+    db_path: String,
+
+    /// Optional: Secret seed to generate consistent Ed25519 identity
+    /// (random if omitted)
+    #[arg(short, long)]
+    seed: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+    let args = Args::parse();
+
+    log::info!("Starting StellarConduit Core Daemon...");
+    log::info!("Configuration:");
+    log::info!("  Port: {}", args.port);
+    log::info!("  Relay Node: {}", args.is_relay);
+    log::info!("  Database: {}", args.db_path);
+    log::info!(
+        "  Identity Seed: {}",
+        if args.seed.is_some() {
+            "provided"
+        } else {
+            "random"
+        }
+    );
+
+    // TODO: 1. Generate or load Identity (Issue #2) from seed
+    // TODO: 2. Initialize Database (Issue #18)
+    // TODO: 3. Start StatePruner (Issue #19)
+    // TODO: 4. Start TransportManager with WiFi-Direct listener (TCP) on `args.port`
+    // TODO: 5. Start Gossip Event Loop
+
+    log::info!("Daemon initialized. Press CTRL+C to shutdown.");
+
+    // Block forever waiting for CTRL+C
+    tokio::signal::ctrl_c().await?;
+    log::info!("Shutting down daemon...");
+    Ok(())
+}


### PR DESCRIPTION
Closes #29 

## Summary
Implements CLI daemon interface for running local mesh nodes during development.

## Changes
- Added `stellarconduitd` binary with clap-based CLI
- Supports `--port`, `--is-relay`, `--db-path`, and `--seed` arguments
- Graceful shutdown on CTRL+C
- TODO markers for integration with pending features

## Usage
```bash
cargo run --bin stellarconduitd -- --help
cargo run --bin stellarconduitd -- --port 9000 --is-relay
```

## Prerequisites
Requires system dependencies:
```bash
sudo apt install libdbus-1-dev pkg-config
```

## Acceptance Criteria
- [x] CLI help documentation
- [x] Port configuration
- [x] Relay flag support
- [x] Database path option
- [x] Seed parameter for deterministic identity

## Integration Points
Ready to integrate with:
- Issue #2 (Message signing)
- Issue #18 (Persistence)
- Issue #19 (State pruning)
- Issue #14 (WiFi transport)