### PR TITLE
test(gossip+topology): add unit tests for all gossip and topology modules (#46)

### DIFF
--- a/tests/gossip_test.rs
+++ b/tests/gossip_test.rs
@@ -1,1 +1,117 @@
+use std::collections::HashSet;
+use std::time::Duration;
 
+// Updated to match your exact submodule structure
+use stellarconduit_core::gossip::bloom::BloomFilter;
+use stellarconduit_core::gossip::fanout::FanoutCalculator;
+use stellarconduit_core::gossip::round::RoundScheduler;
+
+// ==========================================
+// Bloom Filter Tests
+// ==========================================
+
+#[test]
+fn test_bloom_new_message_returns_false() {
+    let mut filter = BloomFilter::new(1000);
+    let message = b"unique_tx_hash_001";
+    assert_eq!(filter.check_and_add(message), false);
+}
+
+#[test]
+fn test_bloom_seen_message_returns_true() {
+    let mut filter = BloomFilter::new(1000);
+    let message = b"unique_tx_hash_002";
+    
+    filter.check_and_add(message);
+    assert_eq!(filter.check_and_add(message), true);
+}
+
+#[test]
+fn test_bloom_rotates_on_capacity() {
+    let mut filter = BloomFilter::new(5);
+    
+    for i in 0..5 {
+        let msg = format!("msg_{}", i);
+        filter.check_and_add(msg.as_bytes());
+    }
+    
+    filter.check_and_add(b"trigger_rotation_msg");
+    assert_eq!(filter.check_and_add(b"msg_0"), true);
+}
+
+#[test]
+fn test_bloom_false_positive_rate_acceptable() {
+    let capacity = 10_000;
+    let mut filter = BloomFilter::new(capacity);
+    
+    for i in 0..capacity {
+        let msg = format!("known_hash_{}", i);
+        filter.check_and_add(msg.as_bytes());
+    }
+    
+    let mut false_positives = 0;
+    let test_sample_size = 1000;
+    
+    for i in 0..test_sample_size {
+        let msg = format!("unknown_hash_{}", i);
+        if filter.check_and_add(msg.as_bytes()) {
+            false_positives += 1;
+        }
+    }
+    
+    let fp_rate = (false_positives as f64) / (test_sample_size as f64);
+    assert!(fp_rate <= 0.05, "False positive rate too high: {:.2}%", fp_rate * 100.0);
+}
+
+// ==========================================
+// Round Scheduler Tests
+// ==========================================
+
+#[test]
+fn test_scheduler_triggers_in_active_mode() {
+    let mut scheduler = RoundScheduler::new();
+    scheduler.record_activity();
+    
+    let interval = scheduler.get_interval();
+    assert!(interval <= Duration::from_millis(500), "Active interval should be fast");
+}
+
+#[test]
+fn test_scheduler_downgrades_to_idle() {
+    let mut scheduler = RoundScheduler::new();
+    scheduler.record_activity();
+    scheduler.advance_time(Duration::from_secs(60));
+    
+    let interval = scheduler.get_interval();
+    assert!(interval >= Duration::from_secs(5), "Idle interval should be slow");
+}
+
+// ==========================================
+// Fanout Calculator Tests
+// ==========================================
+
+#[test]
+fn test_fanout_below_min_returns_all_connections() {
+    let calc = FanoutCalculator::new();
+    assert_eq!(calc.calculate_target(1), 1);
+    assert_eq!(calc.calculate_target(2), 2);
+}
+
+#[test]
+fn test_fanout_above_max_capped() {
+    let calc = FanoutCalculator::new();
+    let target = calc.calculate_target(100);
+    assert!(target <= 6, "Fanout should be capped at MAX_FANOUT. Got: {}", target);
+}
+
+#[test]
+fn test_select_random_peers_unique() {
+    let calc = FanoutCalculator::new();
+    let peers = vec!["peer_A", "peer_B", "peer_C", "peer_D", "peer_E"];
+    
+    let selected = calc.select_random(&peers, 3);
+    assert_eq!(selected.len(), 3);
+    
+    let unique_peers: HashSet<_> = selected.into_iter().collect();
+    assert_eq!(unique_peers.len(), 3, "Selected peers must be strictly unique");
+}

--- a/tests/gossip_test.rs
+++ b/tests/gossip_test.rs
@@ -21,7 +21,7 @@ fn test_bloom_new_message_returns_false() {
 fn test_bloom_seen_message_returns_true() {
     let mut filter = BloomFilter::new(1000);
     let message = b"unique_tx_hash_002";
-    
+
     filter.check_and_add(message);
     assert_eq!(filter.check_and_add(message), true);
 }
@@ -29,12 +29,12 @@ fn test_bloom_seen_message_returns_true() {
 #[test]
 fn test_bloom_rotates_on_capacity() {
     let mut filter = BloomFilter::new(5);
-    
+
     for i in 0..5 {
         let msg = format!("msg_{}", i);
         filter.check_and_add(msg.as_bytes());
     }
-    
+
     filter.check_and_add(b"trigger_rotation_msg");
     assert_eq!(filter.check_and_add(b"msg_0"), true);
 }
@@ -43,24 +43,28 @@ fn test_bloom_rotates_on_capacity() {
 fn test_bloom_false_positive_rate_acceptable() {
     let capacity = 10_000;
     let mut filter = BloomFilter::new(capacity);
-    
+
     for i in 0..capacity {
         let msg = format!("known_hash_{}", i);
         filter.check_and_add(msg.as_bytes());
     }
-    
+
     let mut false_positives = 0;
     let test_sample_size = 1000;
-    
+
     for i in 0..test_sample_size {
         let msg = format!("unknown_hash_{}", i);
         if filter.check_and_add(msg.as_bytes()) {
             false_positives += 1;
         }
     }
-    
+
     let fp_rate = (false_positives as f64) / (test_sample_size as f64);
-    assert!(fp_rate <= 0.05, "False positive rate too high: {:.2}%", fp_rate * 100.0);
+    assert!(
+        fp_rate <= 0.05,
+        "False positive rate too high: {:.2}%",
+        fp_rate * 100.0
+    );
 }
 
 // ==========================================
@@ -71,9 +75,12 @@ fn test_bloom_false_positive_rate_acceptable() {
 fn test_scheduler_triggers_in_active_mode() {
     let mut scheduler = RoundScheduler::new();
     scheduler.record_activity();
-    
+
     let interval = scheduler.get_interval();
-    assert!(interval <= Duration::from_millis(500), "Active interval should be fast");
+    assert!(
+        interval <= Duration::from_millis(500),
+        "Active interval should be fast"
+    );
 }
 
 #[test]
@@ -81,9 +88,12 @@ fn test_scheduler_downgrades_to_idle() {
     let mut scheduler = RoundScheduler::new();
     scheduler.record_activity();
     scheduler.advance_time(Duration::from_secs(60));
-    
+
     let interval = scheduler.get_interval();
-    assert!(interval >= Duration::from_secs(5), "Idle interval should be slow");
+    assert!(
+        interval >= Duration::from_secs(5),
+        "Idle interval should be slow"
+    );
 }
 
 // ==========================================
@@ -101,17 +111,25 @@ fn test_fanout_below_min_returns_all_connections() {
 fn test_fanout_above_max_capped() {
     let calc = FanoutCalculator::new();
     let target = calc.calculate_target(100);
-    assert!(target <= 6, "Fanout should be capped at MAX_FANOUT. Got: {}", target);
+    assert!(
+        target <= 6,
+        "Fanout should be capped at MAX_FANOUT. Got: {}",
+        target
+    );
 }
 
 #[test]
 fn test_select_random_peers_unique() {
     let calc = FanoutCalculator::new();
     let peers = vec!["peer_A", "peer_B", "peer_C", "peer_D", "peer_E"];
-    
+
     let selected = calc.select_random(&peers, 3);
     assert_eq!(selected.len(), 3);
-    
+
     let unique_peers: HashSet<_> = selected.into_iter().collect();
-    assert_eq!(unique_peers.len(), 3, "Selected peers must be strictly unique");
+    assert_eq!(
+        unique_peers.len(),
+        3,
+        "Selected peers must be strictly unique"
+    );
 }

--- a/tests/topology_test.rs
+++ b/tests/topology_test.rs
@@ -1,1 +1,65 @@
+use std::collections::HashSet;
 
+// Updated to match your exact submodule structure
+use stellarconduit_core::topology::graph::MeshGraph; 
+use stellarconduit_core::topology::hop_counter::HopCounter;
+
+// ==========================================
+// Mesh Graph Tests
+// ==========================================
+
+#[test]
+fn test_graph_apply_update_stores_edges() {
+    let mut graph = MeshGraph::new();
+    graph.apply_update("node_A", "node_B");
+    
+    let neighbors = graph.get_neighbors("node_A").expect("node_A should exist in graph");
+    assert!(neighbors.contains("node_B"), "Graph should store the directed edge to node_B");
+}
+
+#[test]
+fn test_graph_get_neighbors_for_unknown_peer_returns_none() {
+    let graph = MeshGraph::new();
+    assert!(graph.get_neighbors("unknown_node").is_none());
+}
+
+#[test]
+fn test_graph_ignores_self_loop_edges() {
+    let mut graph = MeshGraph::new();
+    graph.apply_update("node_A", "node_A");
+    
+    let neighbors = graph.get_neighbors("node_A");
+    if let Some(list) = neighbors {
+        assert!(!list.contains("node_A"), "Self-loops must be ignored");
+    } else {
+        assert!(neighbors.is_none());
+    }
+}
+
+// ==========================================
+// Hop Counter Tests
+// ==========================================
+
+#[test]
+fn test_hop_counter_returns_highest_when_no_connections() {
+    let counter = HopCounter::new();
+    assert_eq!(counter.get_my_hops(), 255);
+}
+
+#[test]
+fn test_hop_counter_calculates_min_plus_one() {
+    let mut counter = HopCounter::new();
+    counter.update_peer("peer_B", 2);
+    assert_eq!(counter.get_my_hops(), 3);
+    
+    counter.update_peer("peer_C", 5);
+    assert_eq!(counter.get_my_hops(), 3);
+}
+
+#[test]
+fn test_hop_counter_recognizes_direct_relay() {
+    let mut counter = HopCounter::new();
+    counter.update_peer("peer_C", 3);
+    counter.update_peer("peer_B", 0);
+    assert_eq!(counter.get_my_hops(), 1);
+}

--- a/tests/topology_test.rs
+++ b/tests/topology_test.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 // Updated to match your exact submodule structure
-use stellarconduit_core::topology::graph::MeshGraph; 
+use stellarconduit_core::topology::graph::MeshGraph;
 use stellarconduit_core::topology::hop_counter::HopCounter;
 
 // ==========================================
@@ -12,9 +12,14 @@ use stellarconduit_core::topology::hop_counter::HopCounter;
 fn test_graph_apply_update_stores_edges() {
     let mut graph = MeshGraph::new();
     graph.apply_update("node_A", "node_B");
-    
-    let neighbors = graph.get_neighbors("node_A").expect("node_A should exist in graph");
-    assert!(neighbors.contains("node_B"), "Graph should store the directed edge to node_B");
+
+    let neighbors = graph
+        .get_neighbors("node_A")
+        .expect("node_A should exist in graph");
+    assert!(
+        neighbors.contains("node_B"),
+        "Graph should store the directed edge to node_B"
+    );
 }
 
 #[test]
@@ -27,7 +32,7 @@ fn test_graph_get_neighbors_for_unknown_peer_returns_none() {
 fn test_graph_ignores_self_loop_edges() {
     let mut graph = MeshGraph::new();
     graph.apply_update("node_A", "node_A");
-    
+
     let neighbors = graph.get_neighbors("node_A");
     if let Some(list) = neighbors {
         assert!(!list.contains("node_A"), "Self-loops must be ignored");
@@ -51,7 +56,7 @@ fn test_hop_counter_calculates_min_plus_one() {
     let mut counter = HopCounter::new();
     counter.update_peer("peer_B", 2);
     assert_eq!(counter.get_my_hops(), 3);
-    
+
     counter.update_peer("peer_C", 5);
     assert_eq!(counter.get_my_hops(), 3);
 }


### PR DESCRIPTION
## Summary
This PR introduces comprehensive integration test suites for the `gossip` and `topology` modules, fulfilling the testing requirements for the recently implemented epidemic broadcast features.

Fixes #46

## Changes Made
* **Gossip Tests (`tests/gossip_test.rs`):** Added tests validating the Bloom filter's false-positive rate and rotation logic, the Round Scheduler's active/idle intervals, and the Fanout Calculator's peer selection limits.
* **Topology Tests (`tests/topology_test.rs`):** Added tests verifying the Mesh Graph's edge storage and self-loop prevention, as well as the Hop Counter's minimum distance calculations.

## Acceptance Criteria Met
- [x] All tests pass with `cargo test --test gossip_test` and `cargo test --test topology_test`.
- [x] Minimum 10 test cases across both files (14 total added).
- [x] Target modules successfully covered without mutating `src/` logic.