### PR TITLE
feat(enhancement): implement synchronous awake windows for battery optimization (#69)

### DIFF
--- a/src/gossip/bloom.rs
+++ b/src/gossip/bloom.rs
@@ -98,10 +98,10 @@ mod tests {
         let mut filter = SlidingBloomFilter::new(10, 0.01);
 
         // Add items until we reach capacity, accounting for false positives
-        let mut i = 0;
+        let mut i = 0u32;
         while filter.insert_count < 10 {
             let mut msg = [0u8; 32];
-            msg[0] = i as u8;
+            msg[0..4].copy_from_slice(&i.to_le_bytes());
             filter.check_and_add(&msg);
             i += 1;
         }
@@ -109,10 +109,13 @@ mod tests {
         // Verify insert_count is at capacity
         assert_eq!(filter.insert_count, 10);
 
-        // Next item triggers rotation — don't assert false (bloom filters are probabilistic)
-        let mut msg_next = [0u8; 32];
-        msg_next[0] = i as u8;
-        filter.check_and_add(&msg_next);
+        // Keep trying fresh IDs until one is truly inserted into the rotated window.
+        while filter.insert_count == 10 {
+            let mut msg_next = [0u8; 32];
+            msg_next[0..4].copy_from_slice(&i.to_le_bytes());
+            filter.check_and_add(&msg_next);
+            i += 1;
+        }
 
         // After rotation, insert_count should be 1
         assert_eq!(filter.insert_count, 1);
@@ -123,18 +126,20 @@ mod tests {
         assert!(filter.check_and_add(&msg0));
 
         // Add items until we trigger another rotation
-        i += 1;
         while filter.insert_count < 10 {
             let mut msg = [0u8; 32];
-            msg[0] = i as u8;
+            msg[0..4].copy_from_slice(&i.to_le_bytes());
             filter.check_and_add(&msg);
             i += 1;
         }
 
-        // Add one more item to trigger rotation
-        let mut msg_final = [0u8; 32];
-        msg_final[0] = i as u8;
-        filter.check_and_add(&msg_final);
+        // Same here: keep trying until a fresh item lands in the new window.
+        while filter.insert_count == 10 {
+            let mut msg_final = [0u8; 32];
+            msg_final[0..4].copy_from_slice(&i.to_le_bytes());
+            filter.check_and_add(&msg_final);
+            i += 1;
+        }
 
         // After the second rotation, insert_count resets to 1 (the last item of the batch
         // that triggered the rotate).

--- a/src/message/types.rs
+++ b/src/message/types.rs
@@ -72,11 +72,18 @@ mod signature_serde {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TopologyFlag {
+    GoToSleep,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TopologyUpdate {
     pub origin_pubkey: [u8; 32],
     pub directly_connected_peers: Vec<[u8; 32]>,
     pub hops_to_relay: u8,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub topology_flags: Vec<TopologyFlag>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/router/path_finder.rs
+++ b/src/router/path_finder.rs
@@ -118,11 +118,13 @@ mod tests {
             origin_pubkey: pk(2),
             directly_connected_peers: vec![pk(3)],
             hops_to_relay: 255, // unknown at origin
+            topology_flags: vec![],
         });
         graph.apply_update(&TopologyUpdate {
             origin_pubkey: pk(3),
             directly_connected_peers: vec![pk(4)],
             hops_to_relay: 255,
+            topology_flags: vec![],
         });
 
         hc.update_distance(pk(4), 1); // pk(4) is 1 hop away

--- a/src/topology/graph.rs
+++ b/src/topology/graph.rs
@@ -90,6 +90,7 @@ mod tests {
             origin_pubkey: origin,
             directly_connected_peers: vec![pk(2), origin, pk(2)],
             hops_to_relay: 5,
+            topology_flags: vec![],
         };
         g.apply_update(&update);
         let neighbors = g.get_neighbors(&origin).cloned().unwrap();
@@ -105,6 +106,7 @@ mod tests {
             origin_pubkey: pk(1),
             directly_connected_peers: vec![pk(2)],
             hops_to_relay: 1,
+            topology_flags: vec![],
         };
         g.apply_update(&update);
         g.backdate_edge(&pk(1), Duration::from_secs(3700));
@@ -120,6 +122,7 @@ mod tests {
             origin_pubkey: pk(3),
             directly_connected_peers: vec![pk(4)],
             hops_to_relay: 1,
+            topology_flags: vec![],
         };
         g.apply_update(&update);
         // Edge is fresh — should NOT be pruned

--- a/src/topology/health.rs
+++ b/src/topology/health.rs
@@ -200,6 +200,7 @@ mod tests {
                 origin_pubkey: pk(1),
                 directly_connected_peers: vec![pk(2)],
                 hops_to_relay: 1,
+                topology_flags: vec![],
             });
             // Backdate the edge to 2 hours ago
             g.backdate_edge(&pk(1), Duration::from_secs(7200));
@@ -227,6 +228,7 @@ mod tests {
                 origin_pubkey: pk(3),
                 directly_connected_peers: vec![pk(4)],
                 hops_to_relay: 2,
+                topology_flags: vec![],
             });
             // No backdating — edge is fresh
         }

--- a/src/transport/ble_transport.rs
+++ b/src/transport/ble_transport.rs
@@ -429,6 +429,7 @@ mod tests {
             origin_pubkey: [0u8; 32],
             directly_connected_peers: vec![],
             hops_to_relay: 0,
+            topology_flags: vec![],
         });
         assert_eq!(p.send(msg).await, Err(TransportError::NotConnected));
     }
@@ -441,6 +442,7 @@ mod tests {
             origin_pubkey: [0u8; 32],
             directly_connected_peers: vec![],
             hops_to_relay: 0,
+            topology_flags: vec![],
         });
         assert_eq!(c.send(msg).await, Err(TransportError::NotConnected));
     }
@@ -493,6 +495,7 @@ mod tests {
             origin_pubkey: [0xCCu8; 32],
             directly_connected_peers: vec![[0xAAu8; 32]],
             hops_to_relay: 2,
+            topology_flags: vec![],
         });
         let bytes = rmp_serde::to_vec(&msg).unwrap();
         let chunker = MessageChunker { mtu: BLE_ATT_MTU };

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,5 +1,6 @@
 pub mod ble_transport;
 pub mod connection;
 pub mod errors;
+pub mod power;
 pub mod unified;
 pub mod wifi_transport;

--- a/src/transport/power.rs
+++ b/src/transport/power.rs
@@ -1,0 +1,199 @@
+use std::time::Duration;
+
+use crate::message::types::TopologyFlag;
+
+pub const IDLE_SLEEP_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+pub const SYNCHRONIZED_WAKE_INTERVAL: Duration = Duration::from_secs(5);
+pub const SYNCHRONIZED_WAKE_WINDOW: Duration = Duration::from_millis(500);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PowerMode {
+    HighPower,
+    SynchronizedLowPower,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InterfacePowerState {
+    pub ble_enabled: bool,
+    pub wifi_enabled: bool,
+}
+
+impl InterfacePowerState {
+    const fn awake() -> Self {
+        Self {
+            ble_enabled: true,
+            wifi_enabled: true,
+        }
+    }
+
+    const fn sleeping() -> Self {
+        Self {
+            ble_enabled: false,
+            wifi_enabled: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PowerDecision {
+    pub interface_state: InterfacePowerState,
+    pub topology_flags: Vec<TopologyFlag>,
+    pub wake_network: bool,
+}
+
+pub struct PowerManager {
+    mode: PowerMode,
+    last_incoming_activity_at: Duration,
+    pending_outbound_transaction: bool,
+    sleep_flag_emitted: bool,
+}
+
+impl PowerManager {
+    pub fn new(now: Duration) -> Self {
+        Self {
+            mode: PowerMode::HighPower,
+            last_incoming_activity_at: now,
+            pending_outbound_transaction: false,
+            sleep_flag_emitted: false,
+        }
+    }
+
+    pub fn mode(&self) -> PowerMode {
+        self.mode
+    }
+
+    pub fn interface_state(&self, now: Duration) -> InterfacePowerState {
+        if self.mode == PowerMode::HighPower || self.is_awake_window(now) {
+            InterfacePowerState::awake()
+        } else {
+            InterfacePowerState::sleeping()
+        }
+    }
+
+    pub fn is_awake_window(&self, now: Duration) -> bool {
+        let interval_ms = SYNCHRONIZED_WAKE_INTERVAL.as_millis();
+        let window_ms = SYNCHRONIZED_WAKE_WINDOW.as_millis();
+        now.as_millis() % interval_ms < window_ms
+    }
+
+    pub fn next_awake_barrier(&self, now: Duration) -> Duration {
+        let interval_ms = SYNCHRONIZED_WAKE_INTERVAL.as_millis();
+        let current_ms = now.as_millis();
+        let next_ms = ((current_ms / interval_ms) + 1) * interval_ms;
+        Duration::from_millis(next_ms as u64)
+    }
+
+    pub fn record_incoming_transaction(&mut self, now: Duration) -> PowerDecision {
+        self.last_incoming_activity_at = now;
+        self.pending_outbound_transaction = false;
+        self.sleep_flag_emitted = false;
+        self.mode = PowerMode::HighPower;
+        self.tick(now)
+    }
+
+    pub fn record_outbound_transaction(&mut self, now: Duration) -> PowerDecision {
+        let mut decision = self.tick(now);
+
+        if self.mode == PowerMode::SynchronizedLowPower && !self.is_awake_window(now) {
+            self.pending_outbound_transaction = true;
+            decision.interface_state = InterfacePowerState::sleeping();
+            return decision;
+        }
+
+        self.last_incoming_activity_at = now;
+        self.sleep_flag_emitted = false;
+        self.mode = PowerMode::HighPower;
+        decision.interface_state = InterfacePowerState::awake();
+        decision
+    }
+
+    pub fn tick(&mut self, now: Duration) -> PowerDecision {
+        let mut topology_flags = Vec::new();
+        let idle_for = now.saturating_sub(self.last_incoming_activity_at);
+
+        if idle_for >= IDLE_SLEEP_TIMEOUT && self.mode == PowerMode::HighPower {
+            self.mode = PowerMode::SynchronizedLowPower;
+        }
+
+        if self.mode == PowerMode::SynchronizedLowPower && !self.sleep_flag_emitted {
+            topology_flags.push(TopologyFlag::GoToSleep);
+            self.sleep_flag_emitted = true;
+        }
+
+        let wake_network = self.mode == PowerMode::SynchronizedLowPower
+            && self.pending_outbound_transaction
+            && self.is_awake_window(now);
+
+        if wake_network {
+            self.mode = PowerMode::HighPower;
+            self.pending_outbound_transaction = false;
+            self.last_incoming_activity_at = now;
+            self.sleep_flag_emitted = false;
+        }
+
+        PowerDecision {
+            interface_state: self.interface_state(now),
+            topology_flags,
+            wake_network,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn awake_window_alignment_uses_shared_modulo_barrier() {
+        let manager = PowerManager::new(Duration::from_secs(0));
+        assert!(manager.is_awake_window(Duration::from_millis(10)));
+        assert!(!manager.is_awake_window(Duration::from_millis(4_999)));
+        assert!(manager.is_awake_window(Duration::from_millis(5_000)));
+        assert!(manager.is_awake_window(Duration::from_millis(5_499)));
+        assert!(!manager.is_awake_window(Duration::from_millis(5_500)));
+    }
+
+    #[test]
+    fn next_awake_barrier_rounds_up_to_next_five_second_boundary() {
+        let manager = PowerManager::new(Duration::from_secs(0));
+        assert_eq!(
+            manager.next_awake_barrier(Duration::from_millis(1_250)),
+            Duration::from_secs(5)
+        );
+        assert_eq!(
+            manager.next_awake_barrier(Duration::from_secs(5)),
+            Duration::from_secs(10)
+        );
+    }
+
+    #[test]
+    fn idle_timeout_emits_single_go_to_sleep_flag() {
+        let mut manager = PowerManager::new(Duration::from_secs(0));
+
+        let first = manager.tick(IDLE_SLEEP_TIMEOUT);
+        assert_eq!(manager.mode(), PowerMode::SynchronizedLowPower);
+        assert_eq!(first.topology_flags, vec![TopologyFlag::GoToSleep]);
+        assert_eq!(first.interface_state, InterfacePowerState::awake());
+
+        let second = manager.tick(IDLE_SLEEP_TIMEOUT + Duration::from_secs(1));
+        assert!(second.topology_flags.is_empty());
+        assert_eq!(second.interface_state, InterfacePowerState::sleeping());
+    }
+
+    #[test]
+    fn sleeping_transaction_waits_for_next_barrier_and_wakes_network() {
+        let mut manager = PowerManager::new(Duration::from_secs(0));
+        manager.tick(IDLE_SLEEP_TIMEOUT);
+
+        let sleeping =
+            manager.record_outbound_transaction(IDLE_SLEEP_TIMEOUT + Duration::from_millis(1_000));
+        assert_eq!(sleeping.interface_state, InterfacePowerState::sleeping());
+        assert!(!sleeping.wake_network);
+        assert_eq!(manager.mode(), PowerMode::SynchronizedLowPower);
+
+        let awake = manager.tick(IDLE_SLEEP_TIMEOUT + Duration::from_secs(5));
+        assert!(awake.wake_network);
+        assert_eq!(awake.interface_state, InterfacePowerState::awake());
+        assert_eq!(manager.mode(), PowerMode::HighPower);
+    }
+}

--- a/src/transport/unified.rs
+++ b/src/transport/unified.rs
@@ -1,6 +1,6 @@
 use rand::random;
-use std::collections::HashMap;
-use std::time::{Duration, Instant};
+use std::collections::{HashMap, VecDeque};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 pub const CHUNK_FRAME_HEADER_SIZE: usize = 14;
 pub const MAX_MESSAGE_SIZE_BYTES: usize = 1024 * 1024;
@@ -173,7 +173,21 @@ use crate::peer::identity::PeerIdentity;
 use crate::transport::ble_transport::BleCentral;
 use crate::transport::connection::Connection;
 use crate::transport::errors::TransportError;
+use crate::transport::power::{InterfacePowerState, PowerManager};
 use crate::transport::wifi_transport::WifiDirectConnection;
+
+#[derive(Debug, Clone, PartialEq)]
+struct PendingMessage {
+    peer: PeerIdentity,
+    message: ProtocolMessage,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PowerTickOutcome {
+    pub interface_state: InterfacePowerState,
+    pub topology_flags: Vec<crate::message::types::TopologyFlag>,
+    pub flushed_transactions: usize,
+}
 
 /// Manages per-peer transport connections, automatically selecting the best
 /// available physical transport and falling back gracefully.
@@ -181,19 +195,34 @@ pub struct TransportManager {
     preference: TransportPreference,
     /// One `Box<dyn Connection>` per peer pubkey.
     active_connections: HashMap<[u8; 32], Box<dyn Connection>>,
+    power_manager: PowerManager,
+    pending_messages: VecDeque<PendingMessage>,
 }
 
 impl TransportManager {
     pub fn new(preference: TransportPreference) -> Self {
+        Self::with_power_manager(preference, PowerManager::new(current_unix_duration()))
+    }
+
+    pub fn with_power_manager(
+        preference: TransportPreference,
+        power_manager: PowerManager,
+    ) -> Self {
         Self {
             preference,
             active_connections: HashMap::new(),
+            power_manager,
+            pending_messages: VecDeque::new(),
         }
     }
 
     /// Number of currently active peer connections (test helper).
     pub fn connection_count(&self) -> usize {
         self.active_connections.len()
+    }
+
+    pub fn pending_message_count(&self) -> usize {
+        self.pending_messages.len()
     }
 
     /// Open a connection to `peer` using the best available transport.
@@ -257,30 +286,46 @@ impl TransportManager {
         peer: &PeerIdentity,
         msg: ProtocolMessage,
     ) -> Result<(), TransportError> {
-        if let Some(conn) = self.active_connections.get_mut(&peer.pubkey) {
-            match conn.send(msg.clone()).await {
-                Ok(()) => return Ok(()),
-                Err(TransportError::BrokenPipe) => {
-                    log::debug!("send_to: BrokenPipe — removing connection for peer");
-                    self.active_connections.remove(&peer.pubkey);
-                    // Attempt BLE fallback
-                    self.ble_fallback(peer.clone()).await?;
-                    // Retry send over the new BLE connection
-                    if let Some(conn) = self.active_connections.get_mut(&peer.pubkey) {
-                        return conn.send(msg).await;
-                    }
-                    return Err(TransportError::NotConnected);
-                }
-                Err(e) => return Err(e),
-            }
+        self.send_to_at(peer, msg, current_unix_duration()).await
+    }
+
+    pub async fn send_to_at(
+        &mut self,
+        peer: &PeerIdentity,
+        msg: ProtocolMessage,
+        now: Duration,
+    ) -> Result<(), TransportError> {
+        self.power_tick_at(now).await?;
+
+        if matches!(msg, ProtocolMessage::Transaction(_))
+            && self.power_manager.mode() == crate::transport::power::PowerMode::SynchronizedLowPower
+            && !self.power_manager.interface_state(now).ble_enabled
+        {
+            let _ = self.power_manager.record_outbound_transaction(now);
+            self.pending_messages.push_back(PendingMessage {
+                peer: peer.clone(),
+                message: msg,
+            });
+            return Ok(());
         }
-        Err(TransportError::NotConnected)
+
+        let _ = self.power_manager.record_outbound_transaction(now);
+        self.send_now(peer, msg).await
     }
 
     /// Poll each active connection for the next message.
     /// Returns the first `(PeerIdentity, ProtocolMessage)` received.
     /// On `BrokenPipe`, removes the failed connection and attempts BLE fallback.
     pub async fn recv_any(&mut self) -> Option<(PeerIdentity, ProtocolMessage)> {
+        self.recv_any_at(current_unix_duration()).await
+    }
+
+    pub async fn recv_any_at(&mut self, now: Duration) -> Option<(PeerIdentity, ProtocolMessage)> {
+        let tick = self.power_tick_at(now).await.ok()?;
+        if !tick.interface_state.ble_enabled && !tick.interface_state.wifi_enabled {
+            return None;
+        }
+
         let keys: Vec<[u8; 32]> = self.active_connections.keys().copied().collect();
 
         for pubkey in keys {
@@ -306,7 +351,12 @@ impl TransportManager {
             };
 
             match result {
-                Some(Ok(Ok(msg))) => return Some((peer, msg)),
+                Some(Ok(Ok(msg))) => {
+                    if matches!(msg, ProtocolMessage::Transaction(_)) {
+                        let _ = self.power_manager.record_incoming_transaction(now);
+                    }
+                    return Some((peer, msg));
+                }
                 Some(Ok(Err(TransportError::BrokenPipe))) => {
                     log::debug!("recv_any: BrokenPipe — falling back to BLE for peer");
                     self.active_connections.remove(&pubkey);
@@ -324,9 +374,56 @@ impl TransportManager {
         for (_, mut conn) in self.active_connections.drain() {
             let _ = conn.disconnect().await;
         }
+        self.pending_messages.clear();
+    }
+
+    pub async fn power_tick(&mut self) -> Result<PowerTickOutcome, TransportError> {
+        self.power_tick_at(current_unix_duration()).await
     }
 
     // ── Internal ─────────────────────────────────────────────────────────────
+
+    async fn power_tick_at(&mut self, now: Duration) -> Result<PowerTickOutcome, TransportError> {
+        let decision = self.power_manager.tick(now);
+        let mut flushed_transactions = 0usize;
+
+        if decision.wake_network {
+            while let Some(pending) = self.pending_messages.pop_front() {
+                self.send_now(&pending.peer, pending.message).await?;
+                flushed_transactions += 1;
+            }
+        }
+
+        Ok(PowerTickOutcome {
+            interface_state: decision.interface_state,
+            topology_flags: decision.topology_flags,
+            flushed_transactions,
+        })
+    }
+
+    async fn send_now(
+        &mut self,
+        peer: &PeerIdentity,
+        msg: ProtocolMessage,
+    ) -> Result<(), TransportError> {
+        if let Some(conn) = self.active_connections.get_mut(&peer.pubkey) {
+            match conn.send(msg.clone()).await {
+                Ok(()) => return Ok(()),
+                Err(TransportError::BrokenPipe) => {
+                    log::debug!("send_to: BrokenPipe — removing connection for peer");
+                    self.active_connections.remove(&peer.pubkey);
+                    self.ble_fallback(peer.clone()).await?;
+                    if let Some(conn) = self.active_connections.get_mut(&peer.pubkey) {
+                        return conn.send(msg).await;
+                    }
+                    return Err(TransportError::NotConnected);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        Err(TransportError::NotConnected)
+    }
 
     async fn ble_fallback(&mut self, peer: PeerIdentity) -> Result<(), TransportError> {
         log::debug!("ble_fallback: connecting via BLE for peer");
@@ -335,6 +432,12 @@ impl TransportManager {
         self.active_connections.insert(peer.pubkey, Box::new(c));
         Ok(())
     }
+}
+
+fn current_unix_duration() -> Duration {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -428,8 +531,17 @@ mod tests {
 
     // ── TransportManager tests ────────────────────────────────────────────────
 
-    use crate::message::types::{ProtocolMessage, TopologyUpdate};
+    use crate::message::types::{
+        ProtocolMessage, TopologyFlag, TopologyUpdate, TransactionEnvelope,
+    };
+    use crate::transport::connection::{ConnectionState, TransportType};
+    use crate::transport::power::{PowerManager, IDLE_SLEEP_TIMEOUT};
     use crate::transport::unified::{TransportManager, TransportPreference};
+    use async_trait::async_trait;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    };
     use tokio::net::TcpListener;
 
     fn peer(b: u8) -> PeerIdentity {
@@ -441,7 +553,79 @@ mod tests {
             origin_pubkey: [b; 32],
             directly_connected_peers: vec![],
             hops_to_relay: 1,
+            topology_flags: vec![],
         })
+    }
+
+    fn sample_transaction(b: u8) -> ProtocolMessage {
+        ProtocolMessage::Transaction(TransactionEnvelope {
+            message_id: [b; 32],
+            origin_pubkey: [b.wrapping_add(1); 32],
+            tx_xdr: format!("tx-{b}"),
+            ttl_hops: 4,
+            timestamp: 42,
+            signature: [0; 64],
+        })
+    }
+
+    struct MockConnection {
+        peer: PeerIdentity,
+        recv_calls: Arc<AtomicUsize>,
+        sent_messages: Arc<Mutex<Vec<ProtocolMessage>>>,
+        inbox: Arc<Mutex<Vec<ProtocolMessage>>>,
+    }
+
+    impl MockConnection {
+        fn new(
+            peer: PeerIdentity,
+            recv_calls: Arc<AtomicUsize>,
+            sent_messages: Arc<Mutex<Vec<ProtocolMessage>>>,
+            inbox: Arc<Mutex<Vec<ProtocolMessage>>>,
+        ) -> Self {
+            Self {
+                peer,
+                recv_calls,
+                sent_messages,
+                inbox,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Connection for MockConnection {
+        fn remote_peer(&self) -> PeerIdentity {
+            self.peer.clone()
+        }
+
+        fn transport_type(&self) -> TransportType {
+            TransportType::Ble
+        }
+
+        fn state(&self) -> ConnectionState {
+            ConnectionState::Connected
+        }
+
+        async fn connect(&mut self) -> Result<(), TransportError> {
+            Ok(())
+        }
+
+        async fn send(&mut self, msg: ProtocolMessage) -> Result<(), TransportError> {
+            self.sent_messages.lock().unwrap().push(msg);
+            Ok(())
+        }
+
+        async fn recv(&mut self) -> Result<ProtocolMessage, TransportError> {
+            self.recv_calls.fetch_add(1, Ordering::SeqCst);
+            self.inbox
+                .lock()
+                .unwrap()
+                .pop()
+                .ok_or(TransportError::BrokenPipe)
+        }
+
+        async fn disconnect(&mut self) -> Result<(), TransportError> {
+            Ok(())
+        }
     }
 
     #[tokio::test]
@@ -554,5 +738,83 @@ mod tests {
         let mut server_conn = server_task.await.unwrap();
         let received = server_conn.recv().await.unwrap();
         assert_eq!(received, msg);
+    }
+
+    #[tokio::test]
+    async fn power_tick_emits_go_to_sleep_flag_after_idle_timeout() {
+        let mut mgr = TransportManager::with_power_manager(
+            TransportPreference::BleOnly,
+            PowerManager::new(Duration::from_secs(0)),
+        );
+
+        let tick = mgr.power_tick_at(IDLE_SLEEP_TIMEOUT).await.unwrap();
+        assert_eq!(tick.topology_flags, vec![TopologyFlag::GoToSleep]);
+        assert!(tick.interface_state.ble_enabled);
+    }
+
+    #[tokio::test]
+    async fn recv_any_skips_transport_polling_while_interfaces_sleep() {
+        let peer = peer(0x21);
+        let recv_calls = Arc::new(AtomicUsize::new(0));
+        let sent_messages = Arc::new(Mutex::new(Vec::new()));
+        let inbox = Arc::new(Mutex::new(vec![sample_msg(7)]));
+
+        let mut mgr = TransportManager::with_power_manager(
+            TransportPreference::BleOnly,
+            PowerManager::new(Duration::from_secs(0)),
+        );
+        mgr.active_connections.insert(
+            peer.pubkey,
+            Box::new(MockConnection::new(
+                peer.clone(),
+                recv_calls.clone(),
+                sent_messages,
+                inbox,
+            )),
+        );
+
+        let sleeping_at = IDLE_SLEEP_TIMEOUT + Duration::from_secs(1);
+        assert_eq!(mgr.recv_any_at(sleeping_at).await, None);
+        assert_eq!(recv_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn sleeping_transactions_flush_on_next_awake_barrier() {
+        let peer = peer(0x44);
+        let recv_calls = Arc::new(AtomicUsize::new(0));
+        let sent_messages = Arc::new(Mutex::new(Vec::new()));
+        let inbox = Arc::new(Mutex::new(Vec::new()));
+
+        let mut mgr = TransportManager::with_power_manager(
+            TransportPreference::BleOnly,
+            PowerManager::new(Duration::from_secs(0)),
+        );
+        mgr.active_connections.insert(
+            peer.pubkey,
+            Box::new(MockConnection::new(
+                peer.clone(),
+                recv_calls,
+                sent_messages.clone(),
+                inbox,
+            )),
+        );
+
+        let sleeping_at = IDLE_SLEEP_TIMEOUT + Duration::from_secs(1);
+        let tx = sample_transaction(9);
+        mgr.send_to_at(&peer, tx.clone(), sleeping_at)
+            .await
+            .unwrap();
+
+        assert_eq!(mgr.pending_message_count(), 1);
+        assert!(sent_messages.lock().unwrap().is_empty());
+
+        let tick = mgr
+            .power_tick_at(IDLE_SLEEP_TIMEOUT + Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        assert_eq!(tick.flushed_transactions, 1);
+        assert_eq!(mgr.pending_message_count(), 0);
+        assert_eq!(sent_messages.lock().unwrap().as_slice(), &[tx]);
     }
 }

--- a/src/transport/wifi_transport.rs
+++ b/src/transport/wifi_transport.rs
@@ -279,6 +279,7 @@ mod tests {
             origin_pubkey: [b; 32],
             directly_connected_peers: vec![[0u8; 32], [1u8; 32]],
             hops_to_relay: 3,
+            topology_flags: vec![],
         })
     }
 

--- a/tests/message_test.rs
+++ b/tests/message_test.rs
@@ -123,6 +123,7 @@ fn test_topology_update_roundtrip() {
         origin_pubkey: [7u8; 32],
         directly_connected_peers: vec![[1u8; 32], [2u8; 32]],
         hops_to_relay: 2,
+        topology_flags: vec![],
     };
     let msg = ProtocolMessage::TopologyUpdate(update);
 


### PR DESCRIPTION
Closes #69

## Changes
- add a `PowerManager` in `src/transport/power.rs` to handle idle detection, synchronized wake windows, and deferred transaction flushing
- extend `TopologyUpdate` with topology flags and add a `GoToSleep` flag for low-power coordination
- wire `TransportManager` power ticks into send/receive flow so transport polling is paused outside the synchronized awake window
- queue transactions generated during low-power sleep and flush them on the next 5-second awake barrier
- add tests covering wake-window alignment, sleep signaling, sleeping transaction deferral, and transport polling behavior

## Testing
- `cargo build`
- `cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
