### PR TITLE
feat(power): implement Issue-039 power management integration (#101)

### DIFF
--- a/src/gossip/round.rs
+++ b/src/gossip/round.rs
@@ -1,6 +1,9 @@
 //! Gossip round scheduling logic.
 
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+
+use crate::transport::power::PowerManager;
 
 pub const ACTIVE_ROUND_INTERVAL_MS: u64 = 500;
 pub const IDLE_ROUND_INTERVAL_MS: u64 = 5_000;
@@ -9,15 +12,25 @@ pub const IDLE_TIMEOUT_SEC: u64 = 30;
 pub struct GossipScheduler {
     last_round_time: Instant,
     pub last_active_msg_time: Instant,
+    power_manager: Option<Arc<Mutex<PowerManager>>>,
 }
 
 impl GossipScheduler {
-    /// Creates a new GossipScheduler initialized to the current time.
     pub fn new() -> Self {
         let now = Instant::now();
         Self {
             last_round_time: now,
             last_active_msg_time: now,
+            power_manager: None,
+        }
+    }
+
+    pub fn with_power_manager(power_manager: Arc<Mutex<PowerManager>>) -> Self {
+        let now = Instant::now();
+        Self {
+            last_round_time: now,
+            last_active_msg_time: now,
+            power_manager: Some(power_manager),
         }
     }
 
@@ -26,12 +39,7 @@ impl GossipScheduler {
     }
 
     pub fn is_time_for_round(&self) -> bool {
-        let interval = if self.is_idle() {
-            Duration::from_millis(IDLE_ROUND_INTERVAL_MS)
-        } else {
-            Duration::from_millis(ACTIVE_ROUND_INTERVAL_MS)
-        };
-        self.last_round_time.elapsed() >= interval
+        self.last_round_time.elapsed() >= self.current_interval()
     }
 
     pub fn round_executed(&mut self) {
@@ -42,7 +50,14 @@ impl GossipScheduler {
         self.last_active_msg_time.elapsed() >= Duration::from_secs(IDLE_TIMEOUT_SEC)
     }
 
+    /// Returns the interval from the PowerManager when one is attached,
+    /// otherwise falls back to the legacy active/idle heuristic.
     pub fn current_interval(&self) -> Duration {
+        if let Some(pm) = &self.power_manager {
+            if let Ok(guard) = pm.lock() {
+                return guard.recommended_round_interval();
+            }
+        }
         if self.is_idle() {
             Duration::from_millis(IDLE_ROUND_INTERVAL_MS)
         } else {
@@ -60,6 +75,7 @@ impl Default for GossipScheduler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::transport::power::{PowerManager, PowerState};
 
     fn scheduler_with_last_round_ago(ago: Duration) -> GossipScheduler {
         let mut s = GossipScheduler::new();
@@ -160,5 +176,21 @@ mod tests {
         assert!(s.is_idle());
         s.record_activity();
         assert!(!s.is_idle());
+    }
+
+    #[test]
+    fn test_power_manager_overrides_interval_in_low_power() {
+        let pm = Arc::new(Mutex::new(PowerManager::new(Duration::from_secs(0))));
+        pm.lock().unwrap().set_state(PowerState::LowPower);
+        let s = GossipScheduler::with_power_manager(Arc::clone(&pm));
+        assert!(s.current_interval() >= Duration::from_secs(5));
+    }
+
+    #[test]
+    fn test_power_manager_overrides_interval_in_deep_sleep() {
+        let pm = Arc::new(Mutex::new(PowerManager::new(Duration::from_secs(0))));
+        pm.lock().unwrap().set_state(PowerState::DeepSleep);
+        let s = GossipScheduler::with_power_manager(Arc::clone(&pm));
+        assert!(s.current_interval() >= Duration::from_secs(60));
     }
 }

--- a/src/message/types.rs
+++ b/src/message/types.rs
@@ -75,6 +75,10 @@ mod signature_serde {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TopologyFlag {
     GoToSleep,
+    /// Device is in duty-cycled BLE mode (2% duty cycle).
+    LowPowerMode,
+    /// Device will enter deep sleep within the next 60s.
+    DeepSleepPending,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/transport/power.rs
+++ b/src/transport/power.rs
@@ -1,11 +1,29 @@
 use std::time::Duration;
 
-use crate::message::types::TopologyFlag;
+use crate::message::types::{TopologyFlag, TopologyUpdate};
 
 pub const IDLE_SLEEP_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 pub const SYNCHRONIZED_WAKE_INTERVAL: Duration = Duration::from_secs(5);
 pub const SYNCHRONIZED_WAKE_WINDOW: Duration = Duration::from_millis(500);
 
+// Duty-cycle windows (on_ms / period_ms)
+const LOW_POWER_BLE_ON_MS: u128 = 200;
+const LOW_POWER_BLE_PERIOD_MS: u128 = 10_000;
+const DEEP_SLEEP_BLE_ON_MS: u128 = 200;
+const DEEP_SLEEP_BLE_PERIOD_MS: u128 = 60_000;
+
+/// Coarse power state for the device.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PowerState {
+    /// Full radio on, gossip rounds at active interval.
+    Active,
+    /// Duty-cycled BLE (2%), gossip rounds at idle interval.
+    LowPower,
+    /// Radio off except for periodic wake-scan (0.33% BLE duty).
+    DeepSleep,
+}
+
+/// Retained for backward compatibility with existing callers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PowerMode {
     HighPower,
@@ -42,21 +60,85 @@ pub struct PowerDecision {
 }
 
 pub struct PowerManager {
+    state: PowerState,
+    // Legacy field kept for existing tick() callers
     mode: PowerMode,
     last_incoming_activity_at: Duration,
     pending_outbound_transaction: bool,
     sleep_flag_emitted: bool,
+    /// Monotonic "now" in ms, updated by the caller via set_state / tick.
+    now_ms: u128,
 }
 
 impl PowerManager {
     pub fn new(now: Duration) -> Self {
         Self {
+            state: PowerState::Active,
             mode: PowerMode::HighPower,
             last_incoming_activity_at: now,
             pending_outbound_transaction: false,
             sleep_flag_emitted: false,
+            now_ms: now.as_millis(),
         }
     }
+
+    // ── New API (Issue-039) ────────────────────────────────────────────────
+
+    /// Recommended gossip round interval for the current power state.
+    pub fn recommended_round_interval(&self) -> Duration {
+        match self.state {
+            PowerState::Active => Duration::from_millis(500),
+            PowerState::LowPower => Duration::from_millis(5_000),
+            PowerState::DeepSleep => Duration::from_millis(60_000),
+        }
+    }
+
+    /// Transition to a new power state and return a `TopologyUpdate` that
+    /// should be immediately broadcast to peers when entering LowPower or
+    /// DeepSleep.
+    pub fn set_state(&mut self, state: PowerState) -> Option<TopologyUpdate> {
+        self.state = state;
+        // Keep legacy mode in sync
+        self.mode = match state {
+            PowerState::Active => PowerMode::HighPower,
+            PowerState::LowPower | PowerState::DeepSleep => PowerMode::SynchronizedLowPower,
+        };
+
+        let flags: Vec<TopologyFlag> = match state {
+            PowerState::Active => return None,
+            PowerState::LowPower => vec![TopologyFlag::LowPowerMode],
+            PowerState::DeepSleep => vec![TopologyFlag::DeepSleepPending],
+        };
+
+        Some(TopologyUpdate {
+            origin_pubkey: [0u8; 32], // caller fills in real pubkey
+            directly_connected_peers: vec![],
+            hops_to_relay: 0,
+            topology_flags: flags,
+        })
+    }
+
+    /// Duty-cycle gate: returns `true` when BLE advertising should be active
+    /// this instant.  Uses a modulo window over `now_ms`.
+    pub fn should_advertise_ble(&self) -> bool {
+        match self.state {
+            PowerState::Active => true,
+            PowerState::LowPower => self.now_ms % LOW_POWER_BLE_PERIOD_MS < LOW_POWER_BLE_ON_MS,
+            PowerState::DeepSleep => self.now_ms % DEEP_SLEEP_BLE_PERIOD_MS < DEEP_SLEEP_BLE_ON_MS,
+        }
+    }
+
+    /// Advance the internal clock so duty-cycle logic can be tested without
+    /// real wall time.
+    pub fn advance_clock(&mut self, now_ms: u128) {
+        self.now_ms = now_ms;
+    }
+
+    pub fn power_state(&self) -> PowerState {
+        self.state
+    }
+
+    // ── Legacy API (kept for backward compat) ─────────────────────────────
 
     pub fn mode(&self) -> PowerMode {
         self.mode
@@ -88,6 +170,7 @@ impl PowerManager {
         self.pending_outbound_transaction = false;
         self.sleep_flag_emitted = false;
         self.mode = PowerMode::HighPower;
+        self.state = PowerState::Active;
         self.tick(now)
     }
 
@@ -103,16 +186,19 @@ impl PowerManager {
         self.last_incoming_activity_at = now;
         self.sleep_flag_emitted = false;
         self.mode = PowerMode::HighPower;
+        self.state = PowerState::Active;
         decision.interface_state = InterfacePowerState::awake();
         decision
     }
 
     pub fn tick(&mut self, now: Duration) -> PowerDecision {
+        self.now_ms = now.as_millis();
         let mut topology_flags = Vec::new();
         let idle_for = now.saturating_sub(self.last_incoming_activity_at);
 
         if idle_for >= IDLE_SLEEP_TIMEOUT && self.mode == PowerMode::HighPower {
             self.mode = PowerMode::SynchronizedLowPower;
+            self.state = PowerState::LowPower;
         }
 
         if self.mode == PowerMode::SynchronizedLowPower && !self.sleep_flag_emitted {
@@ -126,6 +212,7 @@ impl PowerManager {
 
         if wake_network {
             self.mode = PowerMode::HighPower;
+            self.state = PowerState::Active;
             self.pending_outbound_transaction = false;
             self.last_incoming_activity_at = now;
             self.sleep_flag_emitted = false;
@@ -142,6 +229,75 @@ impl PowerManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Issue-039 required tests ──────────────────────────────────────────
+
+    #[test]
+    fn test_power_low_mode_reduces_round_interval() {
+        let mut pm = PowerManager::new(Duration::from_secs(0));
+        pm.set_state(PowerState::LowPower);
+        assert!(pm.recommended_round_interval() >= Duration::from_secs(5));
+    }
+
+    #[test]
+    fn test_duty_cycle_on_time() {
+        // At t=0ms (within first 200ms window) BLE should be on.
+        let mut pm = PowerManager::new(Duration::from_secs(0));
+        pm.set_state(PowerState::LowPower);
+        pm.advance_clock(0);
+        assert!(pm.should_advertise_ble());
+        // Also true at 199ms
+        pm.advance_clock(199);
+        assert!(pm.should_advertise_ble());
+    }
+
+    #[test]
+    fn test_duty_cycle_off_time() {
+        // At 500ms into a 10s window BLE should be off.
+        let mut pm = PowerManager::new(Duration::from_secs(0));
+        pm.set_state(PowerState::LowPower);
+        pm.advance_clock(500);
+        assert!(!pm.should_advertise_ble());
+    }
+
+    #[test]
+    fn test_topology_flag_set_on_low_power_transition() {
+        let mut pm = PowerManager::new(Duration::from_secs(0));
+        let update = pm
+            .set_state(PowerState::LowPower)
+            .expect("should produce topology update");
+        assert!(update.topology_flags.contains(&TopologyFlag::LowPowerMode));
+    }
+
+    #[test]
+    fn test_topology_flag_deep_sleep_pending() {
+        let mut pm = PowerManager::new(Duration::from_secs(0));
+        let update = pm
+            .set_state(PowerState::DeepSleep)
+            .expect("should produce topology update");
+        assert!(update
+            .topology_flags
+            .contains(&TopologyFlag::DeepSleepPending));
+    }
+
+    #[test]
+    fn test_set_state_active_returns_none() {
+        let mut pm = PowerManager::new(Duration::from_secs(0));
+        pm.set_state(PowerState::LowPower);
+        assert!(pm.set_state(PowerState::Active).is_none());
+    }
+
+    #[test]
+    fn test_deep_sleep_interval_larger_than_low_power() {
+        let mut pm = PowerManager::new(Duration::from_secs(0));
+        pm.set_state(PowerState::LowPower);
+        let lp = pm.recommended_round_interval();
+        pm.set_state(PowerState::DeepSleep);
+        let ds = pm.recommended_round_interval();
+        assert!(ds > lp);
+    }
+
+    // ── Legacy tests (kept) ───────────────────────────────────────────────
 
     #[test]
     fn awake_window_alignment_uses_shared_modulo_barrier() {


### PR DESCRIPTION
closes #101 

- Add LowPowerMode and DeepSleepPending to TopologyFlag enum
- Add PowerState enum (Active/LowPower/DeepSleep) to PowerManager
- Add recommended_round_interval(), set_state(), should_advertise_ble(), advance_clock() to PowerManager
- set_state() returns Option<TopologyUpdate> for immediate broadcast on LowPower/DeepSleep transitions (topology flag propagation)
- BLE duty cycle: LowPower 200ms/10s (2%), DeepSleep 200ms/60s (0.33%)
- Integrate PowerManager into GossipScheduler via with_power_manager()
- current_interval() defers to PowerManager when present
- All legacy PowerManager API preserved for backward compat
- Added 7 tests covering all 4 required acceptance criteria