### PR TITLE
feat(gossip): implement anti-entropy pull protocol in run_gossip_loop…

### DIFF
--- a/src/gossip/protocol.rs
+++ b/src/gossip/protocol.rs
@@ -204,11 +204,12 @@ pub async fn run_gossip_loop(
     mut scheduler: GossipScheduler,
     mut strike_tracker: StrikeTracker,
     peer_list: Arc<Mutex<PeerList>>,
-    _transport_manager: Arc<Mutex<TransportManager>>,
+    transport_manager: Arc<Mutex<TransportManager>>,
     event_bus: Option<TopologyEventBus>,
+    state: Arc<Mutex<GossipState>>,
 ) {
-    let mut _anti_entropy_timer = tokio::time::interval(Duration::from_secs(30));
-    let mut ban_check_timer = tokio::time::interval(Duration::from_secs(60)); // Check ban expiration every minute
+    let mut anti_entropy_timer = tokio::time::interval(Duration::from_secs(30));
+    let mut ban_check_timer = tokio::time::interval(Duration::from_secs(60));
 
     // Subscribe to topology events if an event bus is provided.
     let mut topology_events = event_bus.as_ref().map(|bus| bus.subscribe());
@@ -230,10 +231,67 @@ pub async fn run_gossip_loop(
                 }
             }
 
-            // Anti-entropy pull interval (every 30 seconds)
-            _ = _anti_entropy_timer.tick() => {
+            // Anti-entropy pull: every 30 s, pick one random active peer,
+            // send it a SyncRequest, and merge its SyncResponse into our state.
+            _ = anti_entropy_timer.tick() => {
                 log::debug!("Anti-entropy sync timer fired");
-                // TODO: Pick one random active peer and send state.generate_sync_request()
+
+                // Pick one random non-banned active peer.
+                let peer_identity = {
+                    let pl = peer_list.lock().await;
+                    let active: Vec<_> = pl
+                        .get_active_peers()
+                        .into_iter()
+                        .filter(|p| !p.is_banned)
+                        .collect();
+                    if active.is_empty() {
+                        None
+                    } else {
+                        use rand::seq::SliceRandom;
+                        active.choose(&mut rand::thread_rng()).map(|p| p.identity.clone())
+                    }
+                };
+
+                if let Some(peer) = peer_identity {
+                    // Build the sync request from current state.
+                    let sync_req = {
+                        let st = state.lock().await;
+                        st.generate_sync_request()
+                    };
+
+                    let msg = crate::message::types::ProtocolMessage::SyncRequest(sync_req);
+
+                    // Send the SyncRequest to the chosen peer.
+                    let send_result = {
+                        let mut tm = transport_manager.lock().await;
+                        tm.send_to(&peer, msg).await
+                    };
+
+                    match send_result {
+                        Ok(()) => {
+                            log::debug!("Anti-entropy SyncRequest sent to {}", peer);
+                            // Wait for a SyncResponse from the same peer (best-effort).
+                            let response = {
+                                let mut tm = transport_manager.lock().await;
+                                tm.recv_any().await
+                            };
+                            if let Some((from_peer, crate::message::types::ProtocolMessage::SyncResponse(resp))) = response {
+                                if from_peer == peer {
+                                    log::debug!(
+                                        "Anti-entropy SyncResponse from {}: {} envelope(s)",
+                                        peer,
+                                        resp.missing_envelopes.len()
+                                    );
+                                    let mut st = state.lock().await;
+                                    st.handle_sync_response(resp);
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            log::warn!("Anti-entropy SyncRequest to {} failed: {:?}", peer, e);
+                        }
+                    }
+                }
             }
 
             // Check ban expiration periodically
@@ -242,7 +300,6 @@ pub async fn run_gossip_loop(
                 let unbanned = peer_list_guard.check_ban_expirations();
                 if !unbanned.is_empty() {
                     log::info!("Unbanned {} peer(s) after expiration", unbanned.len());
-                    // Clear strike tracker for unbanned peers
                     for peer in unbanned {
                         strike_tracker.clear_peer(&peer);
                     }
@@ -348,12 +405,14 @@ mod tests {
                 crate::transport::unified::TransportPreference::BleOnly,
             ),
         ));
+        let state = Arc::new(Mutex::new(GossipState::new()));
         let handle = tokio::spawn(run_gossip_loop(
             scheduler,
             strike_tracker,
             peer_list,
             transport_manager,
             None,
+            state,
         ));
         let result = timeout(Duration::from_millis(200), async {
             tokio::time::sleep(Duration::from_millis(100)).await;
@@ -373,12 +432,14 @@ mod tests {
                 crate::transport::unified::TransportPreference::BleOnly,
             ),
         ));
+        let state = Arc::new(Mutex::new(GossipState::new()));
         let handle = tokio::spawn(run_gossip_loop(
             scheduler,
             strike_tracker,
             peer_list,
             transport_manager,
             None,
+            state,
         ));
         tokio::time::sleep(Duration::from_millis(50)).await;
         handle.abort();
@@ -399,12 +460,14 @@ mod tests {
                 crate::transport::unified::TransportPreference::BleOnly,
             ),
         ));
+        let state = Arc::new(Mutex::new(GossipState::new()));
         let handle = tokio::spawn(run_gossip_loop(
             scheduler,
             strike_tracker,
             peer_list,
             transport_manager,
             None,
+            state,
         ));
         let result = timeout(Duration::from_millis(150), async {
             tokio::time::sleep(Duration::from_millis(50)).await;

--- a/tests/gossip_test.rs
+++ b/tests/gossip_test.rs
@@ -140,3 +140,167 @@ fn test_select_random_peers_unique() {
         "Selected peers must be strictly unique"
     );
 }
+
+// ==========================================
+// Anti-Entropy Pull Protocol Tests
+// ==========================================
+
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use stellarconduit_core::discovery::peer_list::PeerList;
+use stellarconduit_core::gossip::protocol::{run_gossip_loop, GossipState};
+use stellarconduit_core::gossip::round::GossipScheduler as GossipSched;
+use stellarconduit_core::gossip::strike_tracker::StrikeTracker;
+use stellarconduit_core::message::types::{SyncRequest, SyncResponse, TransactionEnvelope};
+use stellarconduit_core::transport::unified::{TransportManager, TransportPreference};
+
+fn make_envelope(id: u8) -> TransactionEnvelope {
+    TransactionEnvelope {
+        message_id: [id; 32],
+        origin_pubkey: [0u8; 32],
+        tx_xdr: format!("XDR{}", id),
+        ttl_hops: 10,
+        timestamp: id as u64,
+        signature: [0u8; 64],
+    }
+}
+
+/// GossipState::generate_sync_request returns a prefix for every buffered envelope.
+#[test]
+fn test_anti_entropy_sync_request_contains_all_known_ids() {
+    let mut state = GossipState::new();
+    state.add_envelope(make_envelope(0x01));
+    state.add_envelope(make_envelope(0x02));
+    state.add_envelope(make_envelope(0x03));
+
+    let req = state.generate_sync_request();
+    assert_eq!(req.known_message_ids.len(), 3);
+
+    for (i, prefix) in req.known_message_ids.iter().enumerate() {
+        let expected_byte = (i + 1) as u8;
+        assert_eq!(*prefix, [expected_byte; 4]);
+    }
+}
+
+/// Node B asks node A what it's missing; A correctly identifies the delta.
+#[test]
+fn test_anti_entropy_pull_delta_only_missing_envelopes() {
+    let mut node_a = GossipState::new();
+    node_a.add_envelope(make_envelope(0xAA));
+    node_a.add_envelope(make_envelope(0xBB));
+    node_a.add_envelope(make_envelope(0xCC));
+
+    let mut node_b = GossipState::new();
+    node_b.add_envelope(make_envelope(0xAA));
+
+    let req: SyncRequest = node_b.generate_sync_request();
+    let resp: SyncResponse = node_a.handle_sync_request(&req);
+
+    // A should send B the two envelopes it doesn't have.
+    assert_eq!(resp.missing_envelopes.len(), 2);
+    let ids: Vec<u8> = resp
+        .missing_envelopes
+        .iter()
+        .map(|e| e.message_id[0])
+        .collect();
+    assert!(ids.contains(&0xBB));
+    assert!(ids.contains(&0xCC));
+}
+
+/// After a pull, the receiver's queue grows by the right amount.
+#[test]
+fn test_anti_entropy_handle_sync_response_merges_into_queue() {
+    let mut state = GossipState::new();
+    state.add_envelope(make_envelope(0x10));
+
+    let resp = SyncResponse {
+        missing_envelopes: vec![make_envelope(0x20), make_envelope(0x30)],
+    };
+    state.handle_sync_response(resp);
+
+    assert_eq!(state.active_queue.len(), 3);
+}
+
+/// Duplicate envelopes in a SyncResponse are all accepted (dedup is bloom-filter's job).
+#[test]
+fn test_anti_entropy_sync_response_empty_no_panic() {
+    let mut state = GossipState::new();
+    let resp = SyncResponse {
+        missing_envelopes: vec![],
+    };
+    state.handle_sync_response(resp);
+    assert_eq!(state.active_queue.len(), 0);
+}
+
+/// When there are no active peers the gossip loop does not panic or stall.
+#[tokio::test]
+async fn test_anti_entropy_loop_no_peers_does_not_stall() {
+    use tokio::time::timeout;
+
+    let scheduler = GossipSched::new();
+    let strike_tracker = StrikeTracker::new();
+    let peer_list = Arc::new(Mutex::new(PeerList::new(300)));
+    let transport_manager = Arc::new(Mutex::new(TransportManager::new(
+        TransportPreference::BleOnly,
+    )));
+    let state = Arc::new(Mutex::new(GossipState::new()));
+
+    let handle = tokio::spawn(run_gossip_loop(
+        scheduler,
+        strike_tracker,
+        peer_list,
+        transport_manager,
+        None,
+        state,
+    ));
+
+    let result = timeout(Duration::from_millis(200), async {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    })
+    .await;
+    assert!(result.is_ok(), "gossip loop stalled with no peers");
+    handle.abort();
+}
+
+/// The macro-merge backlog path activates for large SyncResponse payloads.
+#[test]
+fn test_anti_entropy_macro_merge_uses_backlog() {
+    use stellarconduit_core::gossip::protocol::MACRO_MERGE_BATCH_SIZE;
+
+    let mut state = GossipState::new();
+
+    // Build a response that exceeds the macro-merge threshold (500).
+    let large_resp = SyncResponse {
+        missing_envelopes: (0u16..501)
+            .map(|i| TransactionEnvelope {
+                message_id: {
+                    let mut id = [0u8; 32];
+                    id[0] = (i >> 8) as u8;
+                    id[1] = (i & 0xFF) as u8;
+                    id
+                },
+                origin_pubkey: [0u8; 32],
+                tx_xdr: format!("XDR{}", i),
+                ttl_hops: 10,
+                timestamp: i as u64,
+                signature: [0u8; 64],
+            })
+            .collect(),
+    };
+
+    state.handle_sync_response(large_resp);
+
+    // Nothing should be in the active queue yet — all in the backlog.
+    assert_eq!(state.active_queue.len(), 0);
+    assert_eq!(state.pending_macro_merge_len(), 501);
+
+    // Process one batch.
+    let moved = state.process_paced_recovery_batch(MACRO_MERGE_BATCH_SIZE);
+    assert_eq!(moved, MACRO_MERGE_BATCH_SIZE);
+    assert_eq!(state.active_queue.len(), MACRO_MERGE_BATCH_SIZE);
+    assert_eq!(
+        state.pending_macro_merge_len(),
+        501 - MACRO_MERGE_BATCH_SIZE
+    );
+}


### PR DESCRIPTION
… (#83)

- Add GossipState parameter to run_gossip_loop so the loop can read and update local message state during anti-entropy rounds
- Replace TODO stub in the 30-second anti-entropy tick with real logic: pick one random non-banned active peer, send a SyncRequest containing known message-ID prefixes, await the SyncResponse, and merge any missing envelopes into local state via handle_sync_response
- Large SyncResponse deltas (>500 envelopes) follow the existing macro-merge backlog path to avoid broadcast storms
- Update the three existing loop unit-tests to supply the new state arg
- Add 6 dedicated anti-entropy tests to gossip_test.rs covering: sync-request prefix generation, delta calculation, response merging, empty-response safety, no-peers loop stability, macro-merge backlog

All tests pass. cargo fmt and cargo clippy -D warnings clean.
closes #83