### PR TITLE
feat(reputation): integrate peer reputation with gossip and transport…

### DIFF
--- a/examples/relay_node_submission.rs
+++ b/examples/relay_node_submission.rs
@@ -67,7 +67,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Origin: {:?}", hex::encode(&envelope.origin_pubkey[..8]));
     println!("Timestamp: {}", envelope.timestamp);
 
-    match relay.process_envelope(&envelope).await {
+    match relay.process_envelope(&envelope, None).await {
         Ok(proof) => {
             println!("✓ Transaction submitted successfully!");
             println!("Proof sequence: {}", proof.sequence);

--- a/src/gossip/protocol.rs
+++ b/src/gossip/protocol.rs
@@ -18,6 +18,7 @@ use crate::message::signing::verify_signature;
 use crate::message::types::{ProtocolMessage, SyncRequest, SyncResponse, TransactionEnvelope};
 use crate::metrics::Metrics;
 use crate::peer::identity::PeerIdentity;
+use crate::peer::reputation::{apply_penalty, PenaltyReason};
 use crate::persistence::db::MeshDatabase;
 use crate::topology::events::TopologyEventBus;
 use crate::transport::unified::TransportManager;
@@ -132,11 +133,25 @@ pub async fn process_transaction_envelope(
             Ok(())
         }
         Ok(false) => {
-            let peer = PeerIdentity::new(envelope.origin_pubkey);
-            Err(GossipError::InvalidSignature { peer })
+            let peer_identity = PeerIdentity::new(envelope.origin_pubkey);
+            {
+                let mut pl = peer_list.lock().await;
+                if let Some(peer) = pl.get_peer_mut(&peer_identity.pubkey) {
+                    apply_penalty(peer, PenaltyReason::InvalidSignature);
+                }
+            }
+            Err(GossipError::InvalidSignature {
+                peer: peer_identity,
+            })
         }
         Err(_) => {
             let peer_identity = PeerIdentity::new(envelope.origin_pubkey);
+            {
+                let mut pl = peer_list.lock().await;
+                if let Some(peer) = pl.get_peer_mut(&peer_identity.pubkey) {
+                    apply_penalty(peer, PenaltyReason::InvalidSignature);
+                }
+            }
             let should_ban = strike_tracker.record_failure(&peer_identity);
             if should_ban {
                 const BAN_DURATION_SEC: u64 = 24 * 60 * 60;
@@ -223,6 +238,7 @@ pub async fn execute_fanout_round(
 
     // 4. For each envelope, apply bloom dedup + TTL, then send to recipients.
     let mut forwarded = 0u64;
+    let mut duplicate_origins: Vec<[u8; 32]> = Vec::new();
     let mut transport = transport_manager.lock().await;
 
     for env in batch {
@@ -231,6 +247,7 @@ pub async fn execute_fanout_round(
             metrics
                 .envelopes_dropped_bloom
                 .fetch_add(1, Ordering::Relaxed);
+            duplicate_origins.push(env.origin_pubkey);
             continue;
         }
 
@@ -260,6 +277,15 @@ pub async fn execute_fanout_round(
     }
 
     drop(transport);
+
+    if !duplicate_origins.is_empty() {
+        let mut pl = peer_list.lock().await;
+        for origin in duplicate_origins {
+            if let Some(peer) = pl.get_peer_mut(&origin) {
+                apply_penalty(peer, PenaltyReason::DuplicateMessageFlood);
+            }
+        }
+    }
 
     let rounds = metrics.gossip_rounds_fired.fetch_add(1, Ordering::Relaxed) + 1;
     metrics
@@ -836,6 +862,50 @@ mod tests {
         .await;
 
         assert_eq!(metrics.envelopes_forwarded.load(Ordering::Relaxed), 5);
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_flood_penalizes_peer() {
+        let fanout_calc = FanoutCalculator::new();
+        let mut bloom = SlidingBloomFilter::new(10_000, 0.01);
+        let metrics = Metrics::new();
+
+        let peer_pubkey = [0x42u8; 32];
+        let peer_list = Arc::new(Mutex::new(PeerList::new(300)));
+        {
+            let mut pl = peer_list.lock().await;
+            pl.insert_or_update(peer_pubkey, 80);
+            if let Some(p) = pl.get_peer_mut(&peer_pubkey) {
+                p.reputation = 50;
+            }
+        }
+
+        let state = Arc::new(Mutex::new(GossipState::new()));
+        {
+            let mut st = state.lock().await;
+            let mut env = mock_envelope(0x42);
+            env.origin_pubkey = peer_pubkey;
+            env.ttl_hops = 5;
+            st.add_envelope(env).unwrap();
+        }
+
+        // Pre-seed bloom so the envelope is already "seen" — next check is a duplicate.
+        bloom.check_and_add(&[0x42u8; 32]);
+
+        let transport_manager = make_transport();
+        execute_fanout_round(
+            &mut bloom,
+            &metrics,
+            &state,
+            &peer_list,
+            &transport_manager,
+            &fanout_calc,
+        )
+        .await;
+
+        let pl = peer_list.lock().await;
+        let peer = pl.get_peer(&peer_pubkey).unwrap();
+        assert_eq!(peer.reputation, 40); // 50 - 10 (DuplicateMessageFlood)
     }
 
     #[tokio::test]

--- a/src/peer/reputation.rs
+++ b/src/peer/reputation.rs
@@ -48,7 +48,7 @@ pub fn apply_reward(peer: &mut Peer, reason: RewardReason) {
 /// Sort a peer slice in-place by reputation, descending.
 /// Call before passing to `select_next_hops` if reputation-based routing is desired.
 pub fn rank_by_reputation(peers: &mut [([u8; 32], u32)]) {
-    peers.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    peers.sort_unstable_by_key(|b| std::cmp::Reverse(b.1));
 }
 
 #[cfg(test)]

--- a/src/peer/reputation.rs
+++ b/src/peer/reputation.rs
@@ -12,7 +12,7 @@ pub enum RewardReason {
 }
 
 impl PenaltyReason {
-    fn points(&self) -> u32 {
+    pub fn points(&self) -> u32 {
         match self {
             PenaltyReason::InvalidSignature => 20,
             PenaltyReason::DuplicateMessageFlood => 10,
@@ -22,7 +22,7 @@ impl PenaltyReason {
 }
 
 impl RewardReason {
-    fn points(&self) -> u32 {
+    pub fn points(&self) -> u32 {
         match self {
             RewardReason::SuccessfullyRoutedTx => 5,
             RewardReason::ValidNewGossipEnvelope => 2,
@@ -30,6 +30,7 @@ impl RewardReason {
     }
 }
 
+/// Subtract penalty points from a peer's reputation; ban the peer when it hits 0.
 pub fn apply_penalty(peer: &mut Peer, reason: PenaltyReason) {
     let penalty = reason.points();
     peer.reputation = peer.reputation.saturating_sub(penalty);
@@ -38,7 +39,54 @@ pub fn apply_penalty(peer: &mut Peer, reason: PenaltyReason) {
     }
 }
 
+/// Add reward points to a peer's reputation, capped at 100.
 pub fn apply_reward(peer: &mut Peer, reason: RewardReason) {
     let reward = reason.points();
     peer.reputation = (peer.reputation + reward).min(100);
+}
+
+/// Sort a peer slice in-place by reputation, descending.
+/// Call before passing to `select_next_hops` if reputation-based routing is desired.
+pub fn rank_by_reputation(peers: &mut [([u8; 32], u32)]) {
+    peers.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::peer::peer_node::Peer;
+
+    #[test]
+    fn test_penalty_degrades_reputation() {
+        let mut peer = Peer::new([1u8; 32]);
+        peer.reputation = 50;
+        apply_penalty(&mut peer, PenaltyReason::InvalidSignature);
+        assert_eq!(peer.reputation, 30);
+    }
+
+    #[test]
+    fn test_penalty_bans_at_zero() {
+        let mut peer = Peer::new([2u8; 32]);
+        peer.reputation = 20;
+        apply_penalty(&mut peer, PenaltyReason::InvalidSignature);
+        assert!(peer.is_banned);
+    }
+
+    #[test]
+    fn test_reward_increases_reputation_capped_at_100() {
+        let mut peer = Peer::new([3u8; 32]);
+        peer.reputation = 98;
+        apply_reward(&mut peer, RewardReason::ValidNewGossipEnvelope);
+        assert_eq!(peer.reputation, 100);
+    }
+
+    #[test]
+    fn test_rank_by_reputation_sorts_descending() {
+        let mut peers: Vec<([u8; 32], u32)> =
+            vec![([1u8; 32], 30), ([2u8; 32], 80), ([3u8; 32], 50)];
+        rank_by_reputation(&mut peers);
+        assert_eq!(peers[0].1, 80);
+        assert_eq!(peers[1].1, 50);
+        assert_eq!(peers[2].1, 30);
+    }
 }

--- a/src/persistence/db.rs
+++ b/src/persistence/db.rs
@@ -534,6 +534,24 @@ impl MeshDatabase {
     }
 }
 
+#[cfg(test)]
+mod reputation_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_reputation_persisted_and_loaded() {
+        let db = MeshDatabase::init(":memory:").await.unwrap();
+        let mut peer = Peer::new([0xAAu8; 32]);
+        peer.reputation = 73;
+
+        db.save_peer(&peer).await.unwrap();
+
+        let peers = db.load_all_peers().await.unwrap();
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].reputation, 73);
+    }
+}
+
 fn vec_to_array<const N: usize>(bytes: Vec<u8>, label: &str) -> Result<[u8; N], DbError> {
     bytes.try_into().map_err(|bytes: Vec<u8>| {
         DbError::InvalidRelayProof(format!("{label} must be {N} bytes, got {}", bytes.len()))

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -11,6 +11,8 @@ use log::info;
 use crate::message::relay_proof::RelayChainProof;
 use crate::message::types::TransactionEnvelope;
 use crate::metrics::Metrics;
+use crate::peer::peer_node::Peer;
+use crate::peer::reputation::{apply_reward, RewardReason};
 use crate::relay::dedup::RelayDeduplicator;
 
 /// Errors returned by the Stellar RPC layer.
@@ -59,9 +61,13 @@ impl RelayNode {
     }
 
     /// Process a transaction envelope, checking for duplicates before submission.
+    ///
+    /// Pass `peer` to apply a reputation reward on the origin peer when the
+    /// transaction is successfully submitted for the first time.
     pub async fn process_envelope(
         &mut self,
         envelope: &TransactionEnvelope,
+        peer: Option<&mut Peer>,
     ) -> Result<RelayChainProof, RpcError> {
         if let Some(existing_proof) = self.deduplicator.check(&envelope.message_id) {
             info!(
@@ -96,6 +102,10 @@ impl RelayNode {
         let proof = RelayChainProof::sign(&self.signing_key, &tx_id, &chain_hash, sequence);
         self.deduplicator
             .mark_submitted(envelope.message_id, proof.clone());
+
+        if let Some(p) = peer {
+            apply_reward(p, RewardReason::SuccessfullyRoutedTx);
+        }
 
         Ok(proof)
     }
@@ -177,11 +187,11 @@ mod tests {
         );
         let envelope = create_test_envelope([1u8; 32]);
 
-        let proof1 = relay.process_envelope(&envelope).await.unwrap();
+        let proof1 = relay.process_envelope(&envelope, None).await.unwrap();
         assert_eq!(submit_count.load(Ordering::SeqCst), 1);
         assert!(proof1.verify(&verifying_key, &[0xABu8; 32]));
 
-        let proof2 = relay.process_envelope(&envelope).await.unwrap();
+        let proof2 = relay.process_envelope(&envelope, None).await.unwrap();
         assert_eq!(submit_count.load(Ordering::SeqCst), 1); // no second call
         assert_eq!(proof1, proof2);
     }
@@ -197,9 +207,9 @@ mod tests {
         );
         let envelope = create_test_envelope([1u8; 32]);
 
-        let p1 = relay.process_envelope(&envelope).await.unwrap();
-        let p2 = relay.process_envelope(&envelope).await.unwrap();
-        let p3 = relay.process_envelope(&envelope).await.unwrap();
+        let p1 = relay.process_envelope(&envelope, None).await.unwrap();
+        let p2 = relay.process_envelope(&envelope, None).await.unwrap();
+        let p3 = relay.process_envelope(&envelope, None).await.unwrap();
 
         assert_eq!(submit_count.load(Ordering::SeqCst), 1);
         assert_eq!(p1, p2);
@@ -217,11 +227,11 @@ mod tests {
         );
 
         relay
-            .process_envelope(&create_test_envelope([1u8; 32]))
+            .process_envelope(&create_test_envelope([1u8; 32]), None)
             .await
             .unwrap();
         relay
-            .process_envelope(&create_test_envelope([2u8; 32]))
+            .process_envelope(&create_test_envelope([2u8; 32]), None)
             .await
             .unwrap();
 
@@ -240,11 +250,11 @@ mod tests {
         );
 
         relay
-            .process_envelope(&create_test_envelope([1u8; 32]))
+            .process_envelope(&create_test_envelope([1u8; 32]), None)
             .await
             .unwrap();
         relay
-            .process_envelope(&create_test_envelope([2u8; 32]))
+            .process_envelope(&create_test_envelope([2u8; 32]), None)
             .await
             .unwrap();
 
@@ -282,7 +292,7 @@ mod tests {
         );
 
         let result = relay
-            .process_envelope(&create_test_envelope([3u8; 32]))
+            .process_envelope(&create_test_envelope([3u8; 32]), None)
             .await;
         assert!(matches!(result, Err(RpcError::TransactionRejected { .. })));
         assert_eq!(metrics.transactions_rejected.load(Ordering::Relaxed), 1);

--- a/tests/integration/double_spend_simulation_test.rs
+++ b/tests/integration/double_spend_simulation_test.rs
@@ -86,7 +86,7 @@ impl TestNode {
             relay
                 .lock()
                 .await
-                .process_envelope(&envelope)
+                .process_envelope(&envelope, None)
                 .await
                 .map_err(|e| e.to_string())?;
         }

--- a/tests/relay_test.rs
+++ b/tests/relay_test.rs
@@ -85,7 +85,9 @@ async fn test_process_envelope_success() {
         Metrics::new(),
     );
 
-    let result = relay.process_envelope(&create_envelope([2u8; 32])).await;
+    let result = relay
+        .process_envelope(&create_envelope([2u8; 32]), None)
+        .await;
 
     assert!(result.is_ok());
     let proof = result.unwrap();
@@ -102,7 +104,9 @@ async fn test_process_envelope_rpc_failure() {
         relay_signing_key(),
         Metrics::new(),
     );
-    let result = relay.process_envelope(&create_envelope([2u8; 32])).await;
+    let result = relay
+        .process_envelope(&create_envelope([2u8; 32]), None)
+        .await;
     assert!(result.is_err());
 }
 
@@ -119,8 +123,8 @@ async fn test_process_envelope_deduplicates() {
     );
     let envelope = create_envelope([2u8; 32]);
 
-    let proof1 = relay.process_envelope(&envelope).await.unwrap();
-    let proof2 = relay.process_envelope(&envelope).await.unwrap();
+    let proof1 = relay.process_envelope(&envelope, None).await.unwrap();
+    let proof2 = relay.process_envelope(&envelope, None).await.unwrap();
 
     assert_eq!(proof1, proof2);
     assert!(proof1.verify(&verifying_key, &tx_id));


### PR DESCRIPTION
… layers

## Summary

Closes #115

This PR wires the previously dormant `apply_penalty` / `apply_reward` functions
into the gossip and relay layers so peer reputation scores actually change at
runtime. All acceptance criteria from #115 are met.

## What changed

### `src/peer/reputation.rs`
- Made `points()` on both enums `pub` (needed by callers)
- Added `rank_by_reputation(peers: &mut [([u8; 32], u32)])` helper — sorts a
  peer slice descending by reputation score before passing to `select_next_hops`
- Added four lib unit tests:
  `test_penalty_degrades_reputation`, `test_penalty_bans_at_zero`,
  `test_reward_increases_reputation_capped_at_100`,
  `test_rank_by_reputation_sorts_descending`

### `src/gossip/protocol.rs`
- `process_transaction_envelope`: calls `apply_penalty(InvalidSignature)` on
  both `Ok(false)` (invalid sig) and `Err(_)` (verification error) paths —
  satisfies "every signature failure" acceptance criterion
- `execute_fanout_round`: when the bloom filter rejects a duplicate, the origin
  pubkey is collected; after the transport lock is released, the list is used
  to call `apply_penalty(DuplicateMessageFlood)` on each origin peer (avoids
  lock-ordering deadlock between transport and peer_list)
- Added `test_duplicate_flood_penalizes_peer` — pre-seeds bloom, queues an
  envelope with a known origin, runs one fanout round, asserts reputation
  decremented by 10

### `src/relay/mod.rs`
- `process_envelope` gains `peer: Option<&mut Peer>` parameter; callers pass
  `None` to skip reward or supply `Some(peer)` to earn
  `RewardReason::SuccessfullyRoutedTx` (+5 reputation) on first successful
  Stellar submission (not on the cached/dedup path)
- All internal test call sites updated to pass `None`

### `src/persistence/db.rs`
- Added `test_reputation_persisted_and_loaded` — saves a peer with
  `reputation = 73`, reloads all peers, asserts the value round-trips correctly
  (the column was already in the schema; this test is the missing proof)

### Other call sites updated
- `tests/relay_test.rs` — 4 call sites
- `tests/integration/double_spend_simulation_test.rs` — 1 call site
- `examples/relay_node_submission.rs` — 1 call site

## Test plan

- [x] `cargo test --lib peer::reputation` — 4 tests pass
- [x] `cargo test --workspace` — all existing + new tests pass, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI green on PR (fmt → clippy → test → integration → bench)

## Acceptance criteria check

| Criterion | Status |
|---|---|
| `apply_penalty(InvalidSignature)` called on every sig failure | ✅ both `Ok(false)` and `Err(_)` branches |
| `apply_penalty(DuplicateMessageFlood)` called on bloom hit | ✅ `execute_fanout_round` |
| `apply_reward(SuccessfullyRoutedTx)` called from relay | ✅ `RelayNode::process_envelope` |
| `reputation` persisted + loaded from SQLite | ✅ already in schema; test added |
| `rank_by_reputation` helper exists | ✅ added to `reputation.rs` |
| `cargo test --lib peer::reputation` passes | ✅ 4/4 |
| No regressions to existing gossip/relay tests | ✅ full workspace green |
