### PR TITLE
Feat/wifi listener inbound

### DIFF
--- a/src/bin/stellarconduitd.rs
+++ b/src/bin/stellarconduitd.rs
@@ -7,6 +7,8 @@ use clap::Parser;
 
 use stellarconduit_core::discovery::mdns::{DiscoveredPeer, MdnsDiscovery};
 use stellarconduit_core::discovery::peer_list::PeerList;
+use stellarconduit_core::peer::identity::PeerIdentity;
+use stellarconduit_core::transport::connection::Connection;
 use stellarconduit_core::transport::unified::{TransportManager, TransportPreference};
 
 #[derive(Parser, Debug)]
@@ -57,8 +59,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // TODO: 2. Initialize Database (Issue #18)
     // TODO: 3. Start StatePruner (Issue #19)
 
-    // TODO: 4. Start TransportManager with WiFi-Direct listener (TCP) on `args.port`
-    let _transport_manager = Arc::new(Mutex::new(TransportManager::new(TransportPreference::Auto)));
+    // 4. Start TransportManager with WiFi-Direct listener (TCP) on `args.port`
+    let transport_manager = Arc::new(Mutex::new(TransportManager::new(TransportPreference::Auto)));
+
+    let (incoming_tx, mut incoming_rx) =
+        mpsc::channel::<(PeerIdentity, Box<dyn Connection + Send + Sync>)>(64);
+
+    let wifi_addr = {
+        let mgr = transport_manager.lock().await;
+        mgr.start_wifi_listener(args.port, incoming_tx).await?
+    };
+    log::info!("WiFi-Direct listener bound on {wifi_addr}");
+
+    let tm_inbound = transport_manager.clone();
+    tokio::spawn(async move {
+        while let Some((peer, conn)) = incoming_rx.recv().await {
+            tm_inbound.lock().await.register_inbound(peer, conn);
+        }
+    });
 
     let peer_list = Arc::new(Mutex::new(PeerList::new(300)));
 

--- a/src/bin/stellarconduitd.rs
+++ b/src/bin/stellarconduitd.rs
@@ -7,8 +7,6 @@ use clap::Parser;
 
 use stellarconduit_core::discovery::mdns::{DiscoveredPeer, MdnsDiscovery};
 use stellarconduit_core::discovery::peer_list::PeerList;
-use stellarconduit_core::peer::identity::PeerIdentity;
-use stellarconduit_core::transport::connection::Connection;
 use stellarconduit_core::transport::unified::{TransportManager, TransportPreference};
 
 #[derive(Parser, Debug)]
@@ -62,8 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 4. Start TransportManager with WiFi-Direct listener (TCP) on `args.port`
     let transport_manager = Arc::new(Mutex::new(TransportManager::new(TransportPreference::Auto)));
 
-    let (incoming_tx, mut incoming_rx) =
-        mpsc::channel::<(PeerIdentity, Box<dyn Connection + Send + Sync>)>(64);
+    let (incoming_tx, mut incoming_rx) = mpsc::channel(64);
 
     let wifi_addr = {
         let mgr = transport_manager.lock().await;

--- a/src/transport/unified.rs
+++ b/src/transport/unified.rs
@@ -428,7 +428,9 @@ impl TransportManager {
         let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{port}"))
             .await
             .map_err(|_| TransportError::ConnectionRefused)?;
-        let bound_addr = listener.local_addr().map_err(|_| TransportError::BrokenPipe)?;
+        let bound_addr = listener
+            .local_addr()
+            .map_err(|_| TransportError::BrokenPipe)?;
 
         let peer_count = Arc::clone(&self.peer_count);
         let max_peers = self.max_peers;
@@ -528,7 +530,11 @@ impl TransportManager {
         log::debug!("ble_fallback: connecting via BLE for peer");
         let mut c = BleCentral::new(peer.clone());
         c.connect().await?;
-        if self.active_connections.insert(peer.pubkey, Box::new(c)).is_none() {
+        if self
+            .active_connections
+            .insert(peer.pubkey, Box::new(c))
+            .is_none()
+        {
             self.peer_count.fetch_add(1, Ordering::SeqCst);
         }
         Ok(())
@@ -932,11 +938,7 @@ mod tests {
             let _ = TcpStream::connect(addr).await;
         });
 
-        let result = tokio::time::timeout(
-            Duration::from_millis(500),
-            rx.recv(),
-        )
-        .await;
+        let result = tokio::time::timeout(Duration::from_millis(500), rx.recv()).await;
         assert!(result.is_ok(), "timed out waiting for inbound connection");
         assert!(result.unwrap().is_some());
     }
@@ -977,7 +979,12 @@ mod tests {
         let inbox = Arc::new(Mutex::new(Vec::new()));
         mgr.register_inbound(
             p.clone(),
-            Box::new(MockConnection::new(p.clone(), recv_calls, sent_messages, inbox)),
+            Box::new(MockConnection::new(
+                p.clone(),
+                recv_calls,
+                sent_messages,
+                inbox,
+            )),
         );
         assert_eq!(mgr.peer_count.load(Ordering::SeqCst), 1);
 
@@ -986,6 +993,9 @@ mod tests {
         let _ = TcpStream::connect(addr).await;
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        assert!(rx.try_recv().is_err(), "connection should have been dropped");
+        assert!(
+            rx.try_recv().is_err(),
+            "connection should have been dropped"
+        );
     }
 }

--- a/src/transport/unified.rs
+++ b/src/transport/unified.rs
@@ -167,6 +167,10 @@ pub enum TransportPreference {
 // ─── TransportManager ─────────────────────────────────────────────────────────
 
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use tokio::sync::{mpsc, watch};
 
 use crate::message::types::ProtocolMessage;
 use crate::peer::identity::PeerIdentity;
@@ -197,6 +201,12 @@ pub struct TransportManager {
     active_connections: HashMap<[u8; 32], Box<dyn Connection>>,
     power_manager: PowerManager,
     pending_messages: VecDeque<PendingMessage>,
+    /// Maximum number of simultaneously connected peers.
+    pub max_peers: usize,
+    /// Atomic mirror of `active_connections.len()` shared with listener tasks.
+    peer_count: Arc<AtomicUsize>,
+    shutdown_tx: watch::Sender<bool>,
+    shutdown_rx: watch::Receiver<bool>,
 }
 
 impl TransportManager {
@@ -208,11 +218,16 @@ impl TransportManager {
         preference: TransportPreference,
         power_manager: PowerManager,
     ) -> Self {
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
         Self {
             preference,
             active_connections: HashMap::new(),
             power_manager,
             pending_messages: VecDeque::new(),
+            max_peers: 300,
+            peer_count: Arc::new(AtomicUsize::new(0)),
+            shutdown_tx,
+            shutdown_rx,
         }
     }
 
@@ -274,7 +289,9 @@ impl TransportManager {
             }
         };
 
-        self.active_connections.insert(peer.pubkey, conn);
+        if self.active_connections.insert(peer.pubkey, conn).is_none() {
+            self.peer_count.fetch_add(1, Ordering::SeqCst);
+        }
         Ok(())
     }
 
@@ -359,7 +376,9 @@ impl TransportManager {
                 }
                 Some(Ok(Err(TransportError::BrokenPipe))) => {
                     log::debug!("recv_any: BrokenPipe — falling back to BLE for peer");
-                    self.active_connections.remove(&pubkey);
+                    if self.active_connections.remove(&pubkey).is_some() {
+                        self.peer_count.fetch_sub(1, Ordering::SeqCst);
+                    }
                     let _ = self.ble_fallback(peer).await;
                 }
                 _ => continue,
@@ -374,6 +393,7 @@ impl TransportManager {
     pub async fn disconnect_peer(&mut self, pubkey: &[u8; 32]) -> bool {
         if let Some(mut conn) = self.active_connections.remove(pubkey) {
             let _ = conn.disconnect().await;
+            self.peer_count.fetch_sub(1, Ordering::SeqCst);
             true
         } else {
             false
@@ -382,10 +402,76 @@ impl TransportManager {
 
     /// Disconnect all active connections and clear the map.
     pub async fn shutdown(&mut self) {
+        let _ = self.shutdown_tx.send(true);
         for (_, mut conn) in self.active_connections.drain() {
             let _ = conn.disconnect().await;
         }
+        self.peer_count.store(0, Ordering::SeqCst);
         self.pending_messages.clear();
+    }
+
+    /// Bind a TCP listener on `0.0.0.0:{port}` and spawn a background task that
+    /// accepts inbound WiFi-Direct (TCP) connections, wraps each as a
+    /// `WifiDirectConnection`, and delivers `(PeerIdentity, Box<dyn Connection>)`
+    /// tuples over `incoming_tx`.
+    ///
+    /// Pass `port = 0` to let the OS pick an ephemeral port; the actual bound
+    /// address is returned so callers can advertise it via mDNS.
+    ///
+    /// Returns `Err(TransportError::ConnectionRefused)` if the port is already in use.
+    /// The background task stops when `shutdown()` is called.
+    pub async fn start_wifi_listener(
+        &self,
+        port: u16,
+        incoming_tx: mpsc::Sender<(PeerIdentity, Box<dyn Connection>)>,
+    ) -> Result<SocketAddr, TransportError> {
+        let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{port}"))
+            .await
+            .map_err(|_| TransportError::ConnectionRefused)?;
+        let bound_addr = listener.local_addr().map_err(|_| TransportError::BrokenPipe)?;
+
+        let peer_count = Arc::clone(&self.peer_count);
+        let max_peers = self.max_peers;
+        let mut shutdown_rx = self.shutdown_rx.clone();
+
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = shutdown_rx.changed() => { break; }
+                    result = listener.accept() => {
+                        match result {
+                            Ok((stream, _)) => {
+                                if peer_count.load(Ordering::SeqCst) >= max_peers {
+                                    log::warn!(
+                                        "max_peers ({max_peers}) reached, dropping inbound connection"
+                                    );
+                                    drop(stream);
+                                    continue;
+                                }
+                                let placeholder = PeerIdentity::new(rand::random());
+                                let conn = WifiDirectConnection::from_stream(stream, placeholder.clone());
+                                let _ = incoming_tx.send((placeholder, Box::new(conn))).await;
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(bound_addr)
+    }
+
+    /// Register an inbound connection accepted externally (e.g. from the gossip loop).
+    ///
+    /// Inserts `conn` into `active_connections` keyed by `peer.pubkey`, replacing
+    /// any existing stale connection.  If a new slot is consumed, `peer_count` is
+    /// incremented so the listener's backpressure check stays accurate.
+    pub fn register_inbound(&mut self, peer: PeerIdentity, conn: Box<dyn Connection>) {
+        if self.active_connections.insert(peer.pubkey, conn).is_none() {
+            self.peer_count.fetch_add(1, Ordering::SeqCst);
+        }
     }
 
     pub async fn power_tick(&mut self) -> Result<PowerTickOutcome, TransportError> {
@@ -422,7 +508,9 @@ impl TransportManager {
                 Ok(()) => return Ok(()),
                 Err(TransportError::BrokenPipe) => {
                     log::debug!("send_to: BrokenPipe — removing connection for peer");
-                    self.active_connections.remove(&peer.pubkey);
+                    if self.active_connections.remove(&peer.pubkey).is_some() {
+                        self.peer_count.fetch_sub(1, Ordering::SeqCst);
+                    }
                     self.ble_fallback(peer.clone()).await?;
                     if let Some(conn) = self.active_connections.get_mut(&peer.pubkey) {
                         return conn.send(msg).await;
@@ -440,7 +528,9 @@ impl TransportManager {
         log::debug!("ble_fallback: connecting via BLE for peer");
         let mut c = BleCentral::new(peer.clone());
         c.connect().await?;
-        self.active_connections.insert(peer.pubkey, Box::new(c));
+        if self.active_connections.insert(peer.pubkey, Box::new(c)).is_none() {
+            self.peer_count.fetch_add(1, Ordering::SeqCst);
+        }
         Ok(())
     }
 }
@@ -553,7 +643,8 @@ mod tests {
         atomic::{AtomicUsize, Ordering},
         Arc, Mutex,
     };
-    use tokio::net::TcpListener;
+    use tokio::net::{TcpListener, TcpStream};
+    use tokio::sync::mpsc;
 
     fn peer(b: u8) -> PeerIdentity {
         PeerIdentity::new([b; 32])
@@ -827,5 +918,74 @@ mod tests {
         assert_eq!(tick.flushed_transactions, 1);
         assert_eq!(mgr.pending_message_count(), 0);
         assert_eq!(sent_messages.lock().unwrap().as_slice(), &[tx]);
+    }
+
+    // ── WiFi listener tests ───────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_wifi_listener_binds_and_accepts() {
+        let (tx, mut rx) = mpsc::channel(8);
+        let mgr = TransportManager::new(TransportPreference::BleOnly);
+        let addr = mgr.start_wifi_listener(0, tx).await.unwrap();
+
+        tokio::spawn(async move {
+            let _ = TcpStream::connect(addr).await;
+        });
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(500),
+            rx.recv(),
+        )
+        .await;
+        assert!(result.is_ok(), "timed out waiting for inbound connection");
+        assert!(result.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_register_inbound_enables_send_to() {
+        let p = peer(0x55);
+        let recv_calls = Arc::new(AtomicUsize::new(0));
+        let sent_messages = Arc::new(Mutex::new(Vec::new()));
+        let inbox = Arc::new(Mutex::new(Vec::new()));
+
+        let mut mgr = TransportManager::new(TransportPreference::BleOnly);
+        mgr.register_inbound(
+            p.clone(),
+            Box::new(MockConnection::new(
+                p.clone(),
+                recv_calls,
+                sent_messages.clone(),
+                inbox,
+            )),
+        );
+        assert_eq!(mgr.connection_count(), 1);
+
+        let msg = sample_msg(42);
+        mgr.send_to(&p, msg.clone()).await.unwrap();
+        assert_eq!(sent_messages.lock().unwrap().as_slice(), &[msg]);
+    }
+
+    #[tokio::test]
+    async fn test_listener_rejects_beyond_max_peers() {
+        let (tx, mut rx) = mpsc::channel(8);
+        let mut mgr = TransportManager::new(TransportPreference::BleOnly);
+        mgr.max_peers = 1;
+
+        let p = peer(0x77);
+        let recv_calls = Arc::new(AtomicUsize::new(0));
+        let sent_messages = Arc::new(Mutex::new(Vec::new()));
+        let inbox = Arc::new(Mutex::new(Vec::new()));
+        mgr.register_inbound(
+            p.clone(),
+            Box::new(MockConnection::new(p.clone(), recv_calls, sent_messages, inbox)),
+        );
+        assert_eq!(mgr.peer_count.load(Ordering::SeqCst), 1);
+
+        let addr = mgr.start_wifi_listener(0, tx).await.unwrap();
+
+        let _ = TcpStream::connect(addr).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        assert!(rx.try_recv().is_err(), "connection should have been dropped");
     }
 }

--- a/src/transport/wifi_transport.rs
+++ b/src/transport/wifi_transport.rs
@@ -85,6 +85,19 @@ impl WifiDirectConnection {
         })
     }
 
+    /// Wraps an already-accepted `TcpStream` as a connected `WifiDirectConnection`
+    /// without performing a new outbound TCP connection.
+    pub fn from_stream(stream: TcpStream, peer: PeerIdentity) -> Self {
+        Self {
+            remote_peer: peer,
+            state: ConnectionState::Connected,
+            stream: Some(stream),
+            addr: None,
+            chunker: MessageChunker { mtu: WIFI_TCP_MTU },
+            reassembler: MessageReassembler::new(),
+        }
+    }
+
     /// Attempt to reconnect using exponential backoff.
     ///
     /// Tries up to `MAX_RECONNECT_ATTEMPTS`. On each failure the delay doubles
@@ -382,6 +395,27 @@ mod tests {
         let result = conn.reconnect().await;
         assert_eq!(result, Err(TransportError::ConnectionRefused));
         assert_eq!(conn.state(), ConnectionState::Disconnected);
+    }
+
+    // ── from_stream constructor ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_from_stream_wraps_accepted_tcp() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let peer = make_peer(0xCC);
+        let peer_clone = peer.clone();
+        let server_task = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            WifiDirectConnection::from_stream(stream, peer_clone)
+        });
+
+        let _client = TcpStream::connect(addr).await.unwrap();
+        let conn = server_task.await.unwrap();
+
+        assert_eq!(conn.remote_peer(), peer);
+        assert_eq!(conn.state(), ConnectionState::Connected);
     }
 
     // ── disconnect clears state ────────────────────────────────────────────────


### PR DESCRIPTION
# feat: Implement start_wifi_listener and WiFi-Direct Inbound Accept Loop in TransportManager

Closes #116

## Summary

- **`WifiDirectConnection::from_stream`** — new constructor that wraps an already-accepted `TcpStream` without making an outbound connection, enabling inbound connection handling (`src/transport/wifi_transport.rs`)
- **`TransportManager::start_wifi_listener(port, tx)`** — binds a `TcpListener` on `0.0.0.0:{port}`, spawns a background Tokio task that loops on `listener.accept()`, wraps each accepted stream as a `WifiDirectConnection`, and delivers `(PeerIdentity, Box<dyn Connection>)` tuples over the provided `mpsc::Sender`; returns the actual bound `SocketAddr` (`src/transport/unified.rs`)
- **`TransportManager::register_inbound(peer, conn)`** — inserts an accepted connection into `active_connections`, updating `peer_count` for backpressure accuracy (`src/transport/unified.rs`)
- **Backpressure** — `max_peers: usize` field (default 300) on `TransportManager`; listener task drops inbound streams and logs `warn!` when `peer_count >= max_peers`
- **Graceful shutdown** — `shutdown()` broadcasts on a `watch` channel so the background accept task exits cleanly
- **Daemon wired up** — `stellarconduitd` creates the inbound `mpsc` channel, calls `start_wifi_listener`, and spawns a consumer that calls `register_inbound` for each accepted connection (`src/bin/stellarconduitd.rs`)

## Tests Added

| Test | What it verifies |
|---|---|
| `transport::unified::tests::test_wifi_listener_binds_and_accepts` | `start_wifi_listener(0, tx)` returns a bound address; a raw TCP connect causes a connection to appear on `rx` within 500 ms |
| `transport::unified::tests::test_register_inbound_enables_send_to` | `register_inbound` inserts a connection so `send_to` works immediately after |
| `transport::unified::tests::test_listener_rejects_beyond_max_peers` | When `active_connections` is at `max_peers`, the next inbound connection is silently dropped (`rx.try_recv()` returns `Err(Empty)`) |
| `transport::wifi_transport::tests::test_from_stream_wraps_accepted_tcp` | `from_stream(stream, peer)` produces a connection where `remote_peer() == peer` and `state() == Connected` |

All 51 transport lib tests pass. `cargo clippy --all-targets -- -D warnings` passes clean.

## Test Plan

- [x] `cargo test --lib transport` — 51/51 pass
- [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [ ] Manual: run `stellarconduitd --port 8080`, connect with `nc 127.0.0.1 8080`, confirm listener binds and accepts
- [ ] Manual: CTRL-C the daemon — confirm clean shutdown with no listener task leaks
