### PR TITLE
Fix/integration send timeouts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 description = "Core mesh networking and gossip protocol for StellarConduit"
 license = "Apache-2.0"
 
+[features]
+default = []
+ble = []
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/src/gossip/queue.rs
+++ b/src/gossip/queue.rs
@@ -29,6 +29,10 @@ impl MessagePriority {
                 MessagePriority::High
             }
             ProtocolMessage::Transaction(_) => MessagePriority::Normal,
+            // Handshake messages are only used at the transport layer during
+            // BLE connection setup and are not gossiped. Assign Low so they
+            // never block protocol messages in the queue.
+            ProtocolMessage::Handshake { .. } => MessagePriority::Low,
         }
     }
 

--- a/src/message/types.rs
+++ b/src/message/types.rs
@@ -116,6 +116,10 @@ pub enum ProtocolMessage {
 
     /// A response containing missing messages requested via SyncRequest
     SyncResponse(SyncResponse),
+
+    /// BLE peer identity handshake — the first message a Central sends after
+    /// connecting to a Peripheral, containing the Central's public key.
+    Handshake { pubkey: [u8; 32] },
 }
 
 impl ProtocolMessage {

--- a/src/transport/ble_transport.rs
+++ b/src/transport/ble_transport.rs
@@ -7,10 +7,23 @@
 //! Unit tests cover state-machine and chunking logic only; BLE integration tests need a real adapter.
 
 use async_trait::async_trait;
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::sync::Mutex;
 use uuid::Uuid;
+
+/// Test-only: number of consecutive times `BlePeripheral::start_advertising`
+/// should fail before succeeding.
+#[cfg(test)]
+static ADVERTISE_FAIL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+/// Set the number of times `start_advertising` should fail (for testing retry logic).
+#[cfg(test)]
+pub fn set_advertise_fail_count(n: usize) {
+    ADVERTISE_FAIL_COUNT.store(n, Ordering::SeqCst);
+}
 
 use crate::message::types::ProtocolMessage;
 use crate::peer::identity::PeerIdentity;
@@ -117,6 +130,14 @@ impl BlePeripheral {
     ///
     /// Returns `Err(TransportError::ConnectionRefused)` if no BLE adapter is available.
     pub async fn start_advertising(&mut self) -> Result<(), TransportError> {
+        #[cfg(test)]
+        {
+            let prev = ADVERTISE_FAIL_COUNT.load(Ordering::SeqCst);
+            if prev > 0 {
+                ADVERTISE_FAIL_COUNT.store(prev - 1, Ordering::SeqCst);
+                return Err(TransportError::ConnectionRefused);
+            }
+        }
         // Platform integration: btleplug adapter acquisition would happen here.
         // For now we transition state to Connected to allow unit-testable logic.
         self.state = ConnectionState::Connected;
@@ -206,6 +227,7 @@ impl Connection for BlePeripheral {
 pub struct BleCentral {
     state: ConnectionState,
     remote_peer: PeerIdentity,
+    local_peer: PeerIdentity,
     chunker: MessageChunker,
     inbox_tx: mpsc::Sender<Vec<u8>>,
     inbox_rx: mpsc::Receiver<Vec<u8>>,
@@ -219,10 +241,17 @@ impl BleCentral {
         Self {
             state: ConnectionState::Disconnected,
             remote_peer,
+            local_peer: PeerIdentity::new([0u8; 32]),
             chunker: MessageChunker { mtu: BLE_ATT_MTU },
             inbox_tx: tx,
             inbox_rx: rx,
         }
+    }
+
+    /// Set the local peer identity so the Handshake is sent with the correct pubkey.
+    pub fn with_local_peer(mut self, local: PeerIdentity) -> Self {
+        self.local_peer = local;
+        self
     }
 
     /// Scan for BLE peripherals advertising `SC_SERVICE_UUID` and connect to the one
@@ -235,11 +264,25 @@ impl BleCentral {
     /// 4. Connect to the matching peripheral, discover characteristics.
     /// 5. Subscribe to the Notify Characteristic, spawning a task that feeds inbound frames
     ///    to the inbox channel via `decode_chunk` / `MessageReassembler`.
+    /// 6. Send a `ProtocolMessage::Handshake` as the first message.
     ///
     /// Returns `Err(TransportError::ConnectionRefused)` if the target cannot be found.
     pub async fn scan_and_connect(&mut self) -> Result<(), TransportError> {
         // Platform integration: btleplug scan + connect would happen here.
         self.state = ConnectionState::Connected;
+
+        // Send Handshake as the first message after connecting.
+        let handshake = ProtocolMessage::Handshake {
+            pubkey: self.local_peer.pubkey,
+        };
+        let bytes = rmp_serde::to_vec(&handshake).map_err(|_| TransportError::BrokenPipe)?;
+        let frames = self.chunker.chunk(&bytes);
+        for frame in frames {
+            let _encoded = encode_chunk(&frame);
+            // Platform integration: write `_encoded` to the remote Peripheral's
+            // Write Characteristic via the btleplug central handle.
+        }
+
         Ok(())
     }
 

--- a/src/transport/unified.rs
+++ b/src/transport/unified.rs
@@ -175,6 +175,8 @@ use tokio::sync::{mpsc, watch};
 use crate::message::types::ProtocolMessage;
 use crate::peer::identity::PeerIdentity;
 use crate::transport::ble_transport::BleCentral;
+#[cfg(feature = "ble")]
+use crate::transport::ble_transport::{BlePeripheral, decode_chunk};
 use crate::transport::connection::Connection;
 use crate::transport::errors::TransportError;
 use crate::transport::power::{InterfacePowerState, PowerManager};
@@ -207,6 +209,16 @@ pub struct TransportManager {
     peer_count: Arc<AtomicUsize>,
     shutdown_tx: watch::Sender<bool>,
     shutdown_rx: watch::Receiver<bool>,
+    /// Sender for injecting raw characteristic write data into the BLE listener.
+    /// Used in tests to simulate peripheral data reception.
+    #[cfg(feature = "ble")]
+    ble_inject_tx: Option<mpsc::Sender<Vec<u8>>>,
+    /// Receiver for inbound BLE connections that have completed the handshake.
+    #[cfg(feature = "ble")]
+    ble_conn_rx: Option<mpsc::Receiver<(PeerIdentity, Box<dyn Connection>)>>,
+    /// Delay between BLE advertising retry attempts when advertising fails.
+    #[cfg(feature = "ble")]
+    ble_advertise_retry_delay: Duration,
 }
 
 impl TransportManager {
@@ -228,6 +240,12 @@ impl TransportManager {
             peer_count: Arc::new(AtomicUsize::new(0)),
             shutdown_tx,
             shutdown_rx,
+            #[cfg(feature = "ble")]
+            ble_inject_tx: None,
+            #[cfg(feature = "ble")]
+            ble_conn_rx: None,
+            #[cfg(feature = "ble")]
+            ble_advertise_retry_delay: Duration::from_secs(30),
         }
     }
 
@@ -465,6 +483,103 @@ impl TransportManager {
         Ok(bound_addr)
     }
 
+    /// Start accepting inbound BLE connections from Central devices.
+    ///
+    /// This method starts a background task that:
+    /// 1. Instantiates a `BlePeripheral` and calls `start_advertising()`.
+    /// 2. Waits for a Central to connect and send a `ProtocolMessage::Handshake`.
+    /// 3. Registers the connection in `self.connections` keyed by the Central's pubkey.
+    /// 4. Loops to accept the next inbound connection.
+    ///
+    /// Returns immediately after spawning the accept task.
+    #[cfg(feature = "ble")]
+    pub async fn start_ble_listener(
+        &mut self,
+        local_peer: PeerIdentity,
+    ) -> Result<(), TransportError> {
+        let (data_tx, mut data_rx) = mpsc::channel::<Vec<u8>>(256);
+        let (conn_tx, conn_rx) = mpsc::channel::<(PeerIdentity, Box<dyn Connection>)>(64);
+
+        self.ble_inject_tx = Some(data_tx);
+        self.ble_conn_rx = Some(conn_rx);
+
+        let mut shutdown_rx = self.shutdown_rx.clone();
+        let peer_count = Arc::clone(&self.peer_count);
+        let max_peers = self.max_peers;
+        let retry_delay = self.ble_advertise_retry_delay;
+
+        tokio::spawn(async move {
+            'outer: loop {
+                // Retry advertising on failure with configurable delay.
+                loop {
+                    let mut peripheral = BlePeripheral::new(local_peer.clone());
+                    match peripheral.start_advertising().await {
+                        Ok(()) => break,
+                        Err(e) => {
+                            log::error!(
+                                "BLE advertising failed: {e:?}; retrying in ~{delay}s",
+                                delay = retry_delay.as_secs(),
+                            );
+                            tokio::time::sleep(retry_delay).await;
+                        }
+                    }
+                }
+
+                // Accept loop — reassemble one connection at a time.
+                let mut reassembler = MessageReassembler::new();
+
+                loop {
+                    tokio::select! {
+                        biased;
+                        _ = shutdown_rx.changed() => break 'outer,
+                        data = data_rx.recv() => {
+                            match data {
+                                Some(bytes) => {
+                                    if peer_count.load(Ordering::SeqCst) >= max_peers {
+                                        log::warn!(
+                                            "max_peers ({max_peers}) reached, dropping inbound BLE"
+                                        );
+                                        continue;
+                                    }
+
+                                    // Decode chunk frame and try to complete a message.
+                                    let Some(frame) = decode_chunk(&bytes) else {
+                                        continue;
+                                    };
+                                    let Some(complete) = reassembler.receive_chunk(frame)
+                                        else {
+                                        continue;
+                                    };
+
+                                    match ProtocolMessage::from_bytes(&complete) {
+                                        Ok(ProtocolMessage::Handshake { pubkey }) => {
+                                            let central_peer = PeerIdentity::new(pubkey);
+                                            let conn: Box<dyn Connection> =
+                                                Box::new(BlePeripheral::new(central_peer.clone()));
+                                            let _ = conn_tx.send((central_peer, conn)).await;
+                                            // Reset for next connection.
+                                            reassembler = MessageReassembler::new();
+                                        }
+                                        _ => {
+                                            log::warn!(
+                                                "First BLE message was not a Handshake; \
+                                                 dropping connection"
+                                            );
+                                            reassembler = MessageReassembler::new();
+                                        }
+                                    }
+                                }
+                                None => break 'outer,
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(())
+    }
+
     /// Register an inbound connection accepted externally (e.g. from the gossip loop).
     ///
     /// Inserts `conn` into `active_connections` keyed by `peer.pubkey`, replacing
@@ -476,6 +591,35 @@ impl TransportManager {
         }
     }
 
+    /// Drain the BLE listener's completed-handshake channel and register any
+    /// ready-to-use connections into `active_connections`.
+    #[cfg(feature = "ble")]
+    fn process_ble_incoming(&mut self) {
+        let mut entries = Vec::new();
+        if let Some(rx) = &mut self.ble_conn_rx {
+            loop {
+                match rx.try_recv() {
+                    Ok((peer, conn)) => entries.push((peer, conn)),
+                    Err(mpsc::error::TryRecvError::Empty) => break,
+                    Err(mpsc::error::TryRecvError::Disconnected) => {
+                        self.ble_conn_rx = None;
+                        break;
+                    }
+                }
+            }
+        }
+        for (peer, conn) in entries {
+            self.register_inbound(peer, conn);
+        }
+    }
+
+    /// Return a clone of the BLE data injection sender, if the listener is running.
+    /// Used in tests to simulate characteristic writes from a Central.
+    #[cfg(feature = "ble")]
+    pub fn ble_inject(&self) -> Option<mpsc::Sender<Vec<u8>>> {
+        self.ble_inject_tx.clone()
+    }
+
     pub async fn power_tick(&mut self) -> Result<PowerTickOutcome, TransportError> {
         self.power_tick_at(current_unix_duration()).await
     }
@@ -483,6 +627,9 @@ impl TransportManager {
     // ── Internal ─────────────────────────────────────────────────────────────
 
     async fn power_tick_at(&mut self, now: Duration) -> Result<PowerTickOutcome, TransportError> {
+        #[cfg(feature = "ble")]
+        self.process_ble_incoming();
+
         let decision = self.power_manager.tick(now);
         let mut flushed_transactions = 0usize;
 
@@ -997,5 +1144,120 @@ mod tests {
             rx.try_recv().is_err(),
             "connection should have been dropped"
         );
+    }
+
+    // ── BLE listener tests ───────────────────────────────────────────────────
+
+    #[cfg(feature = "ble")]
+    #[tokio::test]
+    async fn test_ble_listener_registers_connection_after_handshake() {
+        let local = peer(0xAA);
+        let central_pubkey = [0xBB; 32];
+        let mut mgr = TransportManager::new(TransportPreference::BleOnly);
+        mgr.ble_advertise_retry_delay = Duration::from_millis(5);
+        mgr.start_ble_listener(local).await.unwrap();
+
+        // Give the listener task time to start advertising.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // Inject a Handshake — chunk it like a real BLE characteristic write.
+        let handshake = ProtocolMessage::Handshake {
+            pubkey: central_pubkey,
+        };
+        let bytes = rmp_serde::to_vec(&handshake).unwrap();
+        let chunker = MessageChunker { mtu: 4096 };
+        for frame in chunker.chunk(&bytes) {
+            let raw = crate::transport::ble_transport::encode_chunk(&frame);
+            mgr.ble_inject()
+                .unwrap()
+                .send(raw)
+                .await
+                .unwrap();
+        }
+
+        // Give the listener time to process and register.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // process_ble_incoming is called inside power_tick_at, which recv_any_at
+        // invokes.  Call recv_any once to trigger the drain.
+        let _ = mgr.recv_any_at(Duration::from_secs(0)).await;
+
+        assert!(
+            mgr.active_connections.contains_key(&central_pubkey),
+            "Central's BlePeripheral should have been registered"
+        );
+        assert_eq!(mgr.connection_count(), 1);
+    }
+
+    #[cfg(feature = "ble")]
+    #[tokio::test]
+    async fn test_ble_listener_rejects_non_handshake_first_message() {
+        let local = peer(0xAA);
+        let mut mgr = TransportManager::new(TransportPreference::BleOnly);
+        mgr.ble_advertise_retry_delay = Duration::from_millis(5);
+        mgr.start_ble_listener(local).await.unwrap();
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // Inject a Transaction as the first message (not a Handshake).
+        let tx = sample_transaction(1);
+        let bytes = rmp_serde::to_vec(&tx).unwrap();
+        let chunker = MessageChunker { mtu: 4096 };
+        for frame in chunker.chunk(&bytes) {
+            let raw = crate::transport::ble_transport::encode_chunk(&frame);
+            mgr.ble_inject()
+                .unwrap()
+                .send(raw)
+                .await
+                .unwrap();
+        }
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let _ = mgr.recv_any_at(Duration::from_secs(0)).await;
+
+        // No connection should have been registered.
+        assert_eq!(mgr.connection_count(), 0);
+    }
+
+    #[cfg(feature = "ble")]
+    #[tokio::test]
+    async fn test_ble_listener_retries_on_advertising_failure() {
+        // Make start_advertising fail the first two calls, then succeed.
+        crate::transport::ble_transport::set_advertise_fail_count(2);
+
+        let local = peer(0xAA);
+        let central_pubkey = [0xCC; 32];
+        let mut mgr = TransportManager::new(TransportPreference::BleOnly);
+        mgr.ble_advertise_retry_delay = Duration::from_millis(5);
+        mgr.start_ble_listener(local).await.unwrap();
+
+        // Wait long enough for the two failures + retries + success.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Now inject a Handshake — the listener should be advertising.
+        let handshake = ProtocolMessage::Handshake {
+            pubkey: central_pubkey,
+        };
+        let bytes = rmp_serde::to_vec(&handshake).unwrap();
+        let chunker = MessageChunker { mtu: 4096 };
+        for frame in chunker.chunk(&bytes) {
+            let raw = crate::transport::ble_transport::encode_chunk(&frame);
+            mgr.ble_inject()
+                .unwrap()
+                .send(raw)
+                .await
+                .unwrap();
+        }
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let _ = mgr.recv_any_at(Duration::from_secs(0)).await;
+
+        assert!(
+            mgr.active_connections.contains_key(&central_pubkey),
+            "Connection should be registered after advertising succeeds"
+        );
+
+        // Reset for other tests.
+        crate::transport::ble_transport::set_advertise_fail_count(0);
     }
 }

--- a/tests/gossip_integration_test.rs
+++ b/tests/gossip_integration_test.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 use tokio::net::TcpListener;
+use tokio::time::timeout;
 
 use stellarconduit_core::gossip::protocol::GossipState;
 use stellarconduit_core::message::types::{ProtocolMessage, TransactionEnvelope};
@@ -7,6 +8,18 @@ use stellarconduit_core::peer::identity::PeerIdentity;
 use stellarconduit_core::transport::connection::Connection;
 use stellarconduit_core::transport::unified::{TransportManager, TransportPreference};
 use stellarconduit_core::transport::wifi_transport::WifiDirectConnection;
+
+async fn send_with_timeout<F, T, E>(fut: F, ms: u64, ctx: &str) -> T
+where
+    F: std::future::Future<Output = Result<T, E>>,
+    E: std::fmt::Debug,
+{
+    match timeout(Duration::from_millis(ms), fut).await {
+        Ok(Ok(v)) => v,
+        Ok(Err(e)) => panic!("{} send failed: {:?}", ctx, e),
+        Err(_) => panic!("{} send timed out after {}ms", ctx, ms),
+    }
+}
 
 fn mock_envelope(id_byte: u8, origin: [u8; 32], ttl: u8) -> TransactionEnvelope {
     TransactionEnvelope {
@@ -51,7 +64,7 @@ async fn test_full_gossip_round_delivers_to_peer() {
 
     let batch = state_a.active_queue.drain_batch(32);
     for msg in batch {
-        mgr_a.send_to(&peer_b, msg).await.unwrap();
+        send_with_timeout(mgr_a.send_to(&peer_b, msg), 5000, "mgr_a.send_to(&peer_b)").await;
     }
 
     let mut conn_b = b_conn_task.await.unwrap();
@@ -98,10 +111,12 @@ async fn test_anti_entropy_sync_converges_two_nodes() {
     state_b.add_envelope(env_b1).unwrap();
 
     let req = state_b.generate_sync_request();
-    conn_b_to_a
-        .send(ProtocolMessage::SyncRequest(req))
-        .await
-        .unwrap();
+    send_with_timeout(
+        conn_b_to_a.send(ProtocolMessage::SyncRequest(req)),
+        5000,
+        "conn_b_to_a.send(SyncRequest)",
+    )
+    .await;
 
     let received = conn_a_to_b.recv().await.unwrap();
     let ProtocolMessage::SyncRequest(req) = received else {
@@ -111,10 +126,12 @@ async fn test_anti_entropy_sync_converges_two_nodes() {
     let resp = state_a.handle_sync_request(&req);
     assert_eq!(resp.missing_envelopes.len(), 2);
 
-    conn_a_to_b
-        .send(ProtocolMessage::SyncResponse(resp))
-        .await
-        .unwrap();
+    send_with_timeout(
+        conn_a_to_b.send(ProtocolMessage::SyncResponse(resp)),
+        5000,
+        "conn_a_to_b.send(SyncResponse)",
+    )
+    .await;
 
     let received = conn_b_to_a.recv().await.unwrap();
     let ProtocolMessage::SyncResponse(resp) = received else {
@@ -178,10 +195,12 @@ async fn test_ttl_decrement_prevents_infinite_loops() {
             continue;
         };
         env.ttl_hops = env.ttl_hops.saturating_sub(1);
-        mgr_a
-            .send_to(&peer_b, ProtocolMessage::Transaction(env))
-            .await
-            .unwrap();
+        send_with_timeout(
+            mgr_a.send_to(&peer_b, ProtocolMessage::Transaction(env)),
+            5000,
+            "mgr_a.send_to(&peer_b) (TTL test)",
+        )
+        .await;
     }
 
     let received = b_conn.recv().await.unwrap();
@@ -270,13 +289,13 @@ async fn test_concurrent_gossip_does_not_deadlock() {
 
     let task_a = tokio::spawn(async move {
         for _ in 0..100 {
-            conn_a_to_b.send(msg.clone()).await.unwrap();
+            send_with_timeout(conn_a_to_b.send(msg.clone()), 5000, "conn_a_to_b.send (concurrent)").await;
         }
     });
 
     let task_b = tokio::spawn(async move {
         for _ in 0..100 {
-            conn_b_to_a.send(msg_b.clone()).await.unwrap();
+            send_with_timeout(conn_b_to_a.send(msg_b.clone()), 5000, "conn_b_to_a.send (concurrent)").await;
         }
     });
 


### PR DESCRIPTION
Add BLE Inbound Connection Listener to TransportManager
- Add `ble` feature flag to Cargo.toml
- Add `Handshake` variant to `ProtocolMessage` for BLE peer identity exchange
- `BleCentral::scan_and_connect()` now sends Handshake as first message
- Add `start_ble_listener(&mut self, local_peer)` to `TransportManager`
  - Spawns background task, retries advertising on failure with backoff
  - Validates first message is Handshake, extracts pubkey, registers connection
- Add `ble_inject()` test helper and `process_ble_incoming()` drain
- Update gossip queue priority for Handshake variant
- 3 new tests covering registration, rejection, and advertising retry

Closes https://github.com/StellarConduit/stellarconduit-core/issues/132