### PR TITLE
Add WiFi-Direct survival test for BLE MAC rotation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,10 +56,6 @@ uuid = { version = "1.8", features = ["v4"] }
 # mDNS for WiFi-Direct discovery
 mdns-sd = "0.11"
 
-# HTTP Client for RPC
-reqwest = { version = "0.11", features = ["json"] }
-
-
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = { version = "0.9.11", features = ["vendored"] }

--- a/src/relay/rpc_client.rs
+++ b/src/relay/rpc_client.rs
@@ -91,50 +91,6 @@ struct ResultCodes {
     transaction: Option<String>,
 }
 
-impl RpcClient {
-    /// Create a new RPC client with the given endpoint URL
-    ///
-    /// # Example
-    /// ```
-    /// use stellarconduit_core::relay::rpc_client::RpcClient;
-    ///
-    /// let client = RpcClient::new("https://soroban-testnet.stellar.org");
-    /// ```
-    pub fn new(endpoint: impl Into<String>) -> Self {
-        Self {
-            endpoint: endpoint.into(),
-            http: Client::new(),
-        }
-    }
-
-    /// Submit a base64-encoded XDR transaction to the Soroban network.
-    ///
-    /// # Arguments
-    /// * `tx_xdr` - The base64-encoded Stellar transaction XDR
-    ///
-    /// # Returns
-    /// * `Ok(String)` - The transaction hash on successful submission
-    /// * `Err(RpcError)` - RPC error details if submission fails
-    ///
-    /// # Example
-    /// ```no_run
-    /// # use stellarconduit_core::relay::rpc_client::RpcClient;
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = RpcClient::new("https://soroban-testnet.stellar.org");
-    /// let tx_hash = client.submit_transaction("AAAAAgAAAAD...").await?;
-    /// println!("Transaction hash: {}", tx_hash);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn submit_transaction(&self, tx_xdr: &str) -> Result<String, RpcError> {
-        let request = SorobanRpcRequest {
-            jsonrpc: "2.0",
-            id: 1,
-            method: "sendTransaction",
-            params: SendTxParams {
-                transaction: tx_xdr.to_string(),
-            },
-        };
 // ---------- async trait impl ----------
 
 #[async_trait]

--- a/src/transport/unified.rs
+++ b/src/transport/unified.rs
@@ -1323,6 +1323,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_notify_mac_rotated_drops_ble_keeps_wifi() {
+        use crate::transport::ble_transport::BleCentral;
+
+        // Minimal mock that reports as a WiFi-Direct connection. WiFi-Direct
+        // connections do not reference the BLE MAC, so they must survive a
+        // MAC rotation.
+        struct MockWifiConnection {
+            peer: PeerIdentity,
+        }
+
+        #[async_trait]
+        impl Connection for MockWifiConnection {
+            fn remote_peer(&self) -> PeerIdentity {
+                self.peer.clone()
+            }
+            fn transport_type(&self) -> TransportType {
+                TransportType::WifiDirect
+            }
+            fn state(&self) -> ConnectionState {
+                ConnectionState::Connected
+            }
+            async fn connect(&mut self) -> Result<(), TransportError> {
+                Ok(())
+            }
+            async fn send(&mut self, _msg: ProtocolMessage) -> Result<(), TransportError> {
+                Ok(())
+            }
+            async fn recv(&mut self) -> Result<ProtocolMessage, TransportError> {
+                Err(TransportError::BrokenPipe)
+            }
+            async fn disconnect(&mut self) -> Result<(), TransportError> {
+                Ok(())
+            }
+        }
+
+        let mut mgr = TransportManager::new(TransportPreference::Auto);
+        let ble_peer = peer(0x11);
+        let wifi_peer = peer(0x22);
+
+        // One BLE connection and one WiFi-Direct connection.
+        let ble_conn = Box::new(BleCentral::new(ble_peer.clone()));
+        mgr.active_connections.insert(ble_peer.pubkey, ble_conn);
+        mgr.peer_count.fetch_add(1, Ordering::SeqCst);
+
+        let wifi_conn = Box::new(MockWifiConnection {
+            peer: wifi_peer.clone(),
+        });
+        mgr.active_connections.insert(wifi_peer.pubkey, wifi_conn);
+        mgr.peer_count.fetch_add(1, Ordering::SeqCst);
+
+        assert_eq!(mgr.connection_count(), 2);
+
+        let new_mac = [0xAA, 0x02, 0x00, 0x00, 0x00, 0x00];
+        mgr.notify_mac_rotated(new_mac).await;
+
+        // The BLE connection is dropped; the WiFi-Direct connection is retained.
+        assert_eq!(
+            mgr.connection_count(),
+            1,
+            "WiFi-Direct connection should survive a MAC rotation"
+        );
+        assert!(
+            !mgr.active_connections.contains_key(&ble_peer.pubkey),
+            "BLE connection should be dropped after MAC rotation"
+        );
+        assert!(
+            mgr.active_connections.contains_key(&wifi_peer.pubkey),
+            "WiFi-Direct connection should remain after MAC rotation"
+        );
+        assert_eq!(mgr.peer_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
     async fn test_power_tick_includes_mac_rotated_flag() {
         use crate::transport::ble_transport::BleCentral;
 


### PR DESCRIPTION
closes #117

## Summary

Issue #117 (BLE MAC Address Randomization) defines a set of required tests. The core feature landed in PR #144, but that PR linked `closes #38` (the parent privacy issue) rather than #117, and it did not include one of the required tests. This PR adds the missing test so the final acceptance criterion is actually verified, and links the issue.

It also repairs two unrelated breakages on the base branch that currently prevent CI from compiling the crate at all (see "Build fix" below).

## Gap addressed (#117)

Issue #117 requires the following test under "Required Tests":

> `test_notify_mac_rotated_drops_ble_keeps_wifi` -- Inject one mock BLE connection and one mock WiFi connection. Call `notify_mac_rotated`. Assert BLE removed, WiFi retained.

and the matching acceptance criterion:

> WiFi-Direct connections survive a MAC rotation.

The merged implementation only added `test_notify_mac_rotated_drops_ble_connections`, which inserts two BLE connections and asserts both are dropped. No test exercised a WiFi-Direct connection, so the "WiFi-Direct connections survive a MAC rotation" guarantee was never verified. A regression that accidentally widened `notify_mac_rotated()` to drop non-BLE connections would not have been caught.

### Change

Adds `test_notify_mac_rotated_drops_ble_keeps_wifi` to the `transport::unified` test module:

- Injects one real `BleCentral` connection (`TransportType::Ble`) and one self-contained mock connection reporting `TransportType::WifiDirect`.
- Calls `notify_mac_rotated()`.
- Asserts the BLE connection is removed, the WiFi-Direct connection is retained, and `peer_count` is decremented only for the dropped BLE link.

The mock WiFi connection is defined locally inside the test, so no shared test helpers are modified.

## Build fix

The base branch does not currently compile, which blocks every CI job (fmt, clippy, tests) before it can evaluate the test above. Two unrelated breakages were introduced by an earlier merge:

- `Cargo.toml` declared the `reqwest` dependency twice (0.12 and 0.11), so `cargo metadata` aborted with "duplicate key" and fmt/clippy/test failed immediately. Removed the stale 0.11 entry, keeping the 0.12 `rustls-tls` declaration.
- `src/relay/rpc_client.rs` contained an orphaned `impl RpcClient { ... }` block referencing types that do not exist in the file (`SorobanRpcRequest`, `SendTxParams`, `RpcClient`), leaving an unclosed delimiter and a parse error. The real implementation in this file is `impl StellarRpcClient for HorizonRpcClient`. Removed the orphaned block; no compiled code references the deleted symbols.

## Testing

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --lib
```

All pass. The new test passes specifically:

```
cargo test --lib transport::unified::tests::test_notify_mac_rotated_drops_ble_keeps_wifi
```
